### PR TITLE
MP4 output support (default), custom codec and size

### DIFF
--- a/norfair/video.py
+++ b/norfair/video.py
@@ -47,7 +47,7 @@ class Video:
             BarColumn(),
             "[progress.percentage]{task.percentage:>3.0f}%",
             TimeRemainingColumn(),
-            "[yellow]{task.fields[fps]:.2f}fps",
+            "[yellow]{task.fields[fps]:.2f}fps[/yellow]",
             auto_refresh=False,
             redirect_stdout=False,
             redirect_stderr=False,
@@ -72,7 +72,7 @@ class Video:
         # Cleanup
         if self.output_video is not None:
             self.output_video.release()
-            print(f"[green]Video file saved: [/green][yellow]{self.output_file_path}[/yellow]")
+            print(f"[green]Output video file saved to: [/green][white]{self.output_file_path}[/white]")
         self.video_capture.release()
         cv2.destroyAllWindows()
 


### PR DESCRIPTION
Changes introduced:
* Default output format is now `mp4` instead of `avi`.
* Output video size automatically determined based on the shape of the first frame provided to `Video.write(frame)`.
* Added optional `fourcc_codec` parameter in `norfair.Video()`, which allows saving with any custom codec (e.g: `avc1`, `X264`) provided by the user, as long as it's supported by his OpenCV/ffmpeg installation.
  * If `fourcc_codec` **is provided**, the output file extension is not checked (could be `.mkv` for example, or nothing at all).
  * If `fourcc_codec` is **not provided**, output file extension should be `.mp4` [default], or `.avi`, and the codecs auto-assigned in these cases are `mp4v` or `XVID` respectively.
