### PR TITLE
Get terminal size from native Python

### DIFF
--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 from rich.console import Console
 from rich.table import Table
@@ -36,3 +37,13 @@ def print_objects_as_table(tracked_objects):
             str(obj.initializing_id),
         )
     console.print(table)
+
+def get_terminal_size(default=(80, 24)):
+    columns, lines = default
+    for fd in range(0,3): # First in order 0=Std In, 1=Std Out, 2=Std Error
+        try:
+            columns, lines = os.get_terminal_size(fd)
+        except OSError:
+            continue
+        break    
+    return columns, lines

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -5,6 +5,7 @@ import cv2
 from rich import print
 from rich.progress import BarColumn, Progress, TimeRemainingColumn
 
+from .utils import get_terminal_size
 
 class Video:
     def __init__(
@@ -184,7 +185,7 @@ class Video:
 
     def abbreviate_description(self, description):
         """Conditionally abbreviate description so that progress bar fits in small terminals"""
-        _, terminal_columns = os.popen("stty size", "r").read().split()
+        terminal_columns, _ = get_terminal_size()
         space_for_description = (
             int(terminal_columns) - 25
         )  # Leave 25 space for progressbar


### PR DESCRIPTION
The abbreviate_description method inside Video uses "stty size" which is platform dependent.

From python 3.3, the os.get_terminal_size method is available, which allows obtaining this information from each platform.

A method was created in utils that gets the size of the terminal.

Use the technique of trying to get the value of the first descriptor file without error.
First standard input, then standard output, and finally standard error.
This defensive programming is for those cases in which the pipe redirection exist.
When all cases fail due to not being able to obtain a value, it returns a default value.

Tested on Windows.
It remains to test on Linux and Mac.