### PR TITLE
Downsample only if it is not the value 1

### DIFF
--- a/norfair/video.py
+++ b/norfair/video.py
@@ -146,7 +146,7 @@ class Video:
 
     def show(self, frame: np.array, downsample_ratio: int = 1) -> int:
         # Resize to lower resolution for faster streaming over slow connections
-        if downsample_ratio and downsample_ratio > 1:
+        if downsample_ratio != 1:
             # Note that frame.shape[1] corresponds to width, and opencv format is (width, height)
             frame = cv2.resize(
                 frame,

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -146,7 +146,7 @@ class Video:
 
     def show(self, frame: np.array, downsample_ratio: int = 1) -> int:
         # Resize to lower resolution for faster streaming over slow connections
-        if downsample_ratio is not None:
+        if downsample_ratio not in [0, 1, None]:
             # Note that frame.shape[1] corresponds to width, and opencv format is (width, height)
             frame = cv2.resize(
                 frame,

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -146,7 +146,7 @@ class Video:
 
     def show(self, frame: np.array, downsample_ratio: int = 1) -> int:
         # Resize to lower resolution for faster streaming over slow connections
-        if downsample_ratio not in [0, 1, None]:
+        if downsample_ratio and downsample_ratio > 1:
             # Note that frame.shape[1] corresponds to width, and opencv format is (width, height)
             frame = cv2.resize(
                 frame,


### PR DESCRIPTION
Currently if downsample_ratio is 1, a resize is computed.
By default downsample is always computed by having 1 as the default value on downsample_ratio.
If a zero value is passed, it generates a division by zero.
It is suggested to downsample only if the value is a valid value, not 0, 1 or None.