### PR TITLE
Non-integer downsample_ratio

### DIFF
--- a/norfair/video.py
+++ b/norfair/video.py
@@ -147,12 +147,12 @@ class Video:
     def show(self, frame: np.array, downsample_ratio: float = 1.0) -> int:
         # Resize to lower resolution for faster streaming over slow connections
         if downsample_ratio != 1.0:
-            f = 1.0 / downsample_ratio
             frame = cv2.resize(
-                frame, 
-                dsize = (0,0), 
-                fx = f, 
-                fy = f,
+                frame,
+                (
+                    frame.shape[1] // downsample_ratio,
+                    frame.shape[0] // downsample_ratio,
+                ),
             )
         cv2.imshow("Output", frame)
         return cv2.waitKey(1)

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -146,7 +146,7 @@ class Video:
 
     def show(self, frame: np.array, downsample_ratio: int = 1) -> int:
         # Resize to lower resolution for faster streaming over slow connections
-        if downsample_ratio and downsample_ratio > 1:
+        if downsample_ratio != 1:
             # Note that frame.shape[1] corresponds to width, and opencv format is (width, height)
             frame = cv2.resize(
                 frame,

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -144,16 +144,15 @@ class Video:
         self.output_video.write(frame)
         return cv2.waitKey(1)
 
-    def show(self, frame: np.array, downsample_ratio: int = 1) -> int:
+    def show(self, frame: np.array, downsample_ratio: float = 1.0) -> int:
         # Resize to lower resolution for faster streaming over slow connections
-        if downsample_ratio != 1:
-            # Note that frame.shape[1] corresponds to width, and opencv format is (width, height)
+        if downsample_ratio != 1.0:
+            f = 1.0 / downsample_ratio
             frame = cv2.resize(
-                frame,
-                (
-                    frame.shape[1] // downsample_ratio,
-                    frame.shape[0] // downsample_ratio,
-                ),
+                frame, 
+                dsize = (0,0), 
+                fx = f, 
+                fy = f,
             )
         cv2.imshow("Output", frame)
         return cv2.waitKey(1)

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -146,7 +146,7 @@ class Video:
 
     def show(self, frame: np.array, downsample_ratio: int = 1) -> int:
         # Resize to lower resolution for faster streaming over slow connections
-        if downsample_ratio is not None:
+        if downsample_ratio not in [0, 1, None]:
             # Note that frame.shape[1] corresponds to width, and opencv format is (width, height)
             frame = cv2.resize(
                 frame,

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -146,7 +146,7 @@ class Video:
 
     def show(self, frame: np.array, downsample_ratio: int = 1) -> int:
         # Resize to lower resolution for faster streaming over slow connections
-        if downsample_ratio not in [0, 1, None]:
+        if downsample_ratio and downsample_ratio > 1:
             # Note that frame.shape[1] corresponds to width, and opencv format is (width, height)
             frame = cv2.resize(
                 frame,


### PR DESCRIPTION
It allows you to scale in fractions both down or up.
Method changed to use fx and fy for math simplicity.
Internally opencv optimizes scaling, depending on whether it is a downscale or upscale.

This PR is aligned to the previous one, does not allow scaling to be attempted if the value is the default value.
https://github.com/tryolabs/norfair/pull/15

You can if you want to close the previous PR evaluate the current one.
Both the PR 15 and the current one are intended to minimize the calculations and evaluations on the python side as much as possible. They try to improve the display framerate with small changes.