### PR TITLE
fix missing initialization_delay parameter in update function

### DIFF
--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -15,7 +15,7 @@ class Tracker:
         distance_threshold: float,
         hit_inertia_min: int = 10,
         hit_inertia_max: int = 25,
-        initialization_delay: Optional[int] = None,
+        initialization_delay: Optional[int] = 0,
         detection_threshold: float = 0,
         point_transience: int = 4,
     ):

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -65,6 +65,7 @@ class Tracker:
                     detection,
                     self.hit_inertia_min,
                     self.hit_inertia_max,
+                    self.initialization_delay,
                     self.detection_threshold,
                     self.period,
                     self.point_transience,


### PR DESCRIPTION
TrackedObject is expecting its 4th argument to be initialization_delay, but tracker.update was forgetting to pass it.
The issue was that detection_threshold was initialized with the value of period (1 by default), which lead to incorrect tracking. 