### PR TITLE
Added feature for tracking objects with different classes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Detections returned by the detector must be converted to a `Detection` object be
 - `points`: A numpy array of shape `(number of points per object, 2)`, with each row being a point expressed as `x, y` coordinates on the image. The number of points per detection must be constant for each particular tracker.
 - `scores`: An array of length `number of points per object` which assigns a score to each of the points defined in `points`. This is used to inform the tracker of which points to ignore; any point with a score below `detection_threshold` will be ignored. This useful for cases in which detections don't always have every point present, as is often the case in pose estimators.
 - `data`: The place to store any extra data which may be useful when calculating the distance function. Anything stored here will be available to use inside the distance function. This enables the development of more interesting trackers which can do things like assign an appearance embedding to each detection to aid in its tracking.
+- `label`: When working with multiple classes the detection's label can be stored to be used as a matching condition when associating tracked objects with new detections.
 
 ## FilterSetup
 

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -98,6 +98,13 @@ class Tracker:
             distance_matrix *= self.distance_threshold + 1
             for d, detection in enumerate(detections):
                 for o, obj in enumerate(objects):
+                    if detection.label != obj.label:
+                        distance_matrix[d, o] = self.distance_threshold + 1
+                        if (detection.label is None) or (obj.label is None):
+                            print(
+                                "\nThere are detections with and without label!"
+                            )
+                        continue
                     distance = self.distance_function(detection, obj)
                     # Cap detections and objects with no chance of getting matched so we
                     # dont force the hungarian algorithm to minimize them and therefore
@@ -251,6 +258,7 @@ class TrackedObject:
         # Create Kalman Filter
         self.filter = filter_setup.create_filter(initial_detection_points)
         self.dim_z = 2 * self.num_points
+        self.label = initial_detection.label
 
     def tracker_step(self):
         self.hit_counter -= 1
@@ -363,7 +371,8 @@ class TrackedObject:
 
 
 class Detection:
-    def __init__(self, points: np.array, scores=None, data=None):
+    def __init__(self, points: np.array, scores=None, data=None, label=None):
         self.points = points
         self.scores = scores
         self.data = data
+        self.label = label


### PR DESCRIPTION
Norfair can now handle detections with different classes within a single Tracker instance. Detection and TrackedObject instances can now have a label which is used as a matching condition when building the distance matrix. Only detections and objects with the same label will get matched.

Handling detections with and without labels within a single Tracker instance was out of scope (by default they will never get matched) and in case it happens a message is printed warning the user of this situation.