### PR TITLE
Remove redundant CI lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,6 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.1
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
-
       - name: Run tests
         run: |
           python3 -m venv ./venv


### PR DESCRIPTION
We were already upgrading pip in our virtualenv and we are no longer using tox.