### PR TITLE
Support n-dimensional tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Norfair is a customizable lightweight Python library for real-time multi-object 
 Using Norfair, you can add tracking capabilities to any detector with just a few lines of code.
 
 <img src="/docs/soccer.gif" alt="Tracking soccer players with Norfair and a moving camera." width="500px" />
+<img src="/docs/3d.gif" alt="Tracking soccer players with Norfair and a moving camera." width="500px" />
 
 ## Features
 
@@ -67,6 +68,7 @@ Most tracking demos are showcased with vehicles and pedestrians, but the detecto
 2. [Track both bounding boxes and human keypoints](demos/keypoints_bounding_boxes) (multi-class), unifying the detections from a YOLO model and OpenPose.
 3. [Re-identification (ReID)](demos/reid) of tracked objects using appearance embeddings. This is a good starting point for scenarios with a lot of occlusion, in which the Kalman filter alone would struggle.
 4. [Accurately track objects even if the camera is moving](demos/camera_motion), by estimating camera motion potentially accounting for pan, tilt, rotation, movement in any direction, and zoom.
+5. [Track points in 3D](demos/3d_track), using [MediaPipe Objectron](https://google.github.io/mediapipe/solutions/objectron.html).
 
 ### Benchmarking and profiling
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Norfair is a customizable lightweight Python library for real-time multi-object 
 
 Using Norfair, you can add tracking capabilities to any detector with just a few lines of code.
 
-<img src="/docs/soccer.gif" alt="Tracking soccer players with Norfair and a moving camera." width="500px" />
-<img src="/docs/3d.gif" alt="Tracking soccer players with Norfair and a moving camera." width="500px" />
+<p float="left">
+  <img src="/docs/soccer.gif" alt="Tracking soccer players with Norfair and a moving camera." width="400px" />
+  <img src="/docs/3d.gif" alt="Tracking 3D objects." width="400px" />
+</p>
 
 ## Features
 

--- a/demos/3d_track/Dockerfile
+++ b/demos/3d_track/Dockerfile
@@ -10,6 +10,6 @@ RUN pip install --upgrade pip && \
     pip install mediapipe==0.8.10.1 && \
     pip install opencv-python==4.5.5.64
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@n-dimensional-track#egg=norfair
+RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
 
 WORKDIR /demo/src/

--- a/demos/3d_track/Dockerfile
+++ b/demos/3d_track/Dockerfile
@@ -1,0 +1,15 @@
+#  https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags
+FROM nvcr.io/nvidia/pytorch:22.08-py3
+
+RUN apt-get update && \
+    apt-get install -y libgl1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip && \
+    pip install mediapipe==0.8.10.1 && \
+    pip install opencv-python==4.5.5.64
+
+RUN pip install git+https://github.com/tryolabs/norfair.git@n-dimensional-track#egg=norfair
+
+WORKDIR /demo/src/

--- a/demos/3d_track/README.md
+++ b/demos/3d_track/README.md
@@ -14,10 +14,10 @@
     python demo.py video.mp4
     ```
 
-For additional settings, you may display the instructions using `python demo.py --help`.
+For additional settings, you may display the instructions using `python demo.py --help`. For the demo, we are using [this footage](https://www.pexels.com/video/city-landmark-faceless-architecture-4929210/).
 
 ## Explanation
 
 This example tracks objects using 3D bounding boxes.
 
-![3D Tracking demo](../../docs/skate_lastdet.gif)
+![3D Tracking demo](../../docs/skate3d.gif)

--- a/demos/3d_track/README.md
+++ b/demos/3d_track/README.md
@@ -5,14 +5,12 @@
 ## Instructions
 
 1. Build and run the Docker container with `./run_gpu.sh`.
-
 2. Copy a video to the `src` folder.
-
 3. Within the container, run with the default parameters:
 
-    ```bash
-    python demo.py video.mp4
-    ```
+   ```bash
+   python demo.py video.mp4
+   ```
 
 For additional settings, you may display the instructions using `python demo.py --help`. For the demo, we are using [this footage](https://www.pexels.com/video/man-showing-the-steps-in-hip-hop-dancing-2795737/).
 

--- a/demos/3d_track/README.md
+++ b/demos/3d_track/README.md
@@ -1,0 +1,23 @@
+# 3D-Tracking Example
+
+3D-tracking example based on [MediaPipe Objectron](https://google.github.io/mediapipe/solutions/objectron.html).
+
+## Instructions
+
+1. Build and run the Docker container with `./run_gpu.sh`.
+
+2. Copy a video to the `src` folder.
+
+3. Within the container, run with the default parameters:
+
+    ```bash
+    python demo.py video.mp4
+    ```
+
+For additional settings, you may display the instructions using `python demo.py --help`.
+
+## Explanation
+
+This example tracks objects using 3D bounding boxes.
+
+![3D Tracking demo](../../docs/skate_lastdet.gif)

--- a/demos/3d_track/README.md
+++ b/demos/3d_track/README.md
@@ -20,4 +20,4 @@ For additional settings, you may display the instructions using `python demo.py 
 
 This example tracks objects using 3D bounding boxes.
 
-![3D Tracking demo](../../docs/dance_3d.gif)
+https://user-images.githubusercontent.com/70915567/187745152-7c0b173a-a6b1-49bb-849d-29605ecb17a4.mp4

--- a/demos/3d_track/README.md
+++ b/demos/3d_track/README.md
@@ -14,10 +14,10 @@
     python demo.py video.mp4
     ```
 
-For additional settings, you may display the instructions using `python demo.py --help`. For the demo, we are using [this footage](https://www.pexels.com/video/city-landmark-faceless-architecture-4929210/).
+For additional settings, you may display the instructions using `python demo.py --help`. For the demo, we are using [this footage](https://www.pexels.com/video/man-showing-the-steps-in-hip-hop-dancing-2795737/).
 
 ## Explanation
 
 This example tracks objects using 3D bounding boxes.
 
-![3D Tracking demo](../../docs/skate3d.gif)
+![3D Tracking demo](../../docs/dance_3d.gif)

--- a/demos/3d_track/README.md
+++ b/demos/3d_track/README.md
@@ -20,4 +20,4 @@ For additional settings, you may display the instructions using `python demo.py 
 
 This example tracks objects using 3D bounding boxes.
 
-https://user-images.githubusercontent.com/70915567/187745152-7c0b173a-a6b1-49bb-849d-29605ecb17a4.mp4
+https://user-images.githubusercontent.com/70915567/187967263-ad45c0c7-483f-4f15-b1b9-27678456080b.mp4

--- a/demos/3d_track/run_gpu.sh
+++ b/demos/3d_track/run_gpu.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S bash -e
+docker build . -t norfair-3d
+docker run -it --rm \
+           --gpus all \
+           -v `realpath .`:/demo \
+           norfair-3d \
+           bash

--- a/demos/3d_track/src/demo.py
+++ b/demos/3d_track/src/demo.py
@@ -5,6 +5,7 @@ import cv2
 import mediapipe as mp
 
 from norfair import Video, Detection, Tracker
+from norfair.drawing import Paths
 from norfair.distances import mean_euclidean
 
 from utils import PixelCoordinatesProjecter, draw_3d_tracked_boxes
@@ -13,9 +14,10 @@ parser = argparse.ArgumentParser(description="3d-Track objects in a video.")
 parser.add_argument("files", type=str, nargs="+", help="Video files to process")
 parser.add_argument("--model-name", type=str, default="Shoe", help="model name ('Shoe', 'Chair', 'Cup', 'Camera')")
 parser.add_argument("--max-objects", type=int, default="2", help="Maximum number of objects at a time")
-parser.add_argument("--conf-threshold", type=float, default="0.1", help="Detector threshold") # 0.2
-parser.add_argument("--distance-threshold", type=float, default="0.5", help="Detector threshold") # 0.2
+parser.add_argument("--conf-threshold", type=float, default="0.1", help="Detector threshold") 
+parser.add_argument("--distance-threshold", type=float, default="0.5", help="Detector threshold")
 parser.add_argument("--output-path", type=str, default=".", help="Output path")
+parser.add_argument("--draw-paths", action="store_true", help="Draw path of the centroid")
 args = parser.parse_args()
 
 mp_objectron = mp.solutions.objectron
@@ -38,6 +40,12 @@ with mp_objectron.Objectron(static_image_mode=True,
                 # Set function that projects 3d objets to the pixel space
                 projecter = PixelCoordinatesProjecter(frame.shape[:2][::-1])
 
+                if args.draw_paths:
+                    # initialize path drawer
+                    def get_points_to_draw(points3d):
+                        return [projecter.eye_2_pixel(points3d)[0].astype(int)]
+                    path_drawer = Paths(get_points_to_draw)
+
             detections = []
 
             # Convert the BGR image to RGB and process it with MediaPipe Objectron.
@@ -56,4 +64,7 @@ with mp_objectron.Objectron(static_image_mode=True,
             tracked_objects = tracker.update(detections)
 
             frame = draw_3d_tracked_boxes(frame, tracked_objects, projecter=projecter.eye_2_pixel)
+            if args.draw_paths:
+                frame = path_drawer.draw(frame, tracked_objects)
+
             video.write(frame)

--- a/demos/3d_track/src/demo.py
+++ b/demos/3d_track/src/demo.py
@@ -1,0 +1,61 @@
+import argparse
+
+import numpy as np
+import cv2
+import mediapipe as mp
+
+from norfair import Video, Detection, Tracker, Color
+from norfair.distances import mean_euclidean
+
+parser = argparse.ArgumentParser(description="3d-Track objects in a video.")
+parser.add_argument("files", type=str, nargs="+", help="Video files to process")
+parser.add_argument("--model-name", type=str, default="Shoe", help="model name ('Shoe', 'Chair', 'Cup', 'Camera')")
+parser.add_argument("--max-objects", type=int, default="2", help="Maximum number of objects at a time")
+parser.add_argument("--conf-threshold", type=float, default="0.1", help="Detector threshold") # 0.2
+parser.add_argument("--distance-threshold", type=float, default="0.5", help="Detector threshold") # 0.2
+parser.add_argument("--output-path", type=str, default=".", help="Output path")
+args = parser.parse_args()
+
+mp_drawing = mp.solutions.drawing_utils
+mp_objectron = mp.solutions.objectron
+
+with mp_objectron.Objectron(static_image_mode=True,
+                            max_num_objects=args.max_objects,
+                            min_detection_confidence=args.conf_threshold,
+                            model_name=args.model_name) as objectron:
+
+    for input_path in args.files:
+        video = Video(input_path = input_path, output_path = args.output_path)
+
+        tracker = Tracker(
+            distance_function=mean_euclidean,
+            distance_threshold=args.distance_threshold,
+        )
+        for image in video:
+            detections = []
+
+            # Convert the BGR image to RGB and process it with MediaPipe Objectron.
+            results = objectron.process(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+            
+            # Draw box landmarks.
+            if not results.detected_objects:
+                video.write(image)
+                tracker.update(detections)
+                continue
+ 
+            annotated_image = image.copy()
+            for detected_object in results.detected_objects:
+ 
+                points = np.array([[p.x, p.y, p.z] for p in detected_object.landmarks_3d.landmark])
+                detections.append(Detection(points=points, data=detected_object))
+
+
+            tracked_objects = tracker.update(detections)
+            
+            for obj in tracked_objects:
+                color_spec = mp_drawing.DrawingSpec(color=Color.random(obj.id), thickness=5)
+                mp_drawing.draw_landmarks(annotated_image, obj.last_detection.data.landmarks_2d, mp_objectron.BOX_CONNECTIONS, color_spec, color_spec)
+                # mp_drawing.draw_axis(annotated_image, obj.last_detection.data.rotation, obj.last_detection.data.translation)
+
+            video.write(annotated_image)
+            

--- a/demos/3d_track/src/demo.py
+++ b/demos/3d_track/src/demo.py
@@ -20,7 +20,12 @@ parser.add_argument("--conf-threshold", type=float, default="0.1", help="Detecto
 parser.add_argument("--distance-threshold", type=float, default="0.5", help="Distance threshold")
 parser.add_argument("--output-path", type=str, default=".", help="Output path")
 parser.add_argument("--draw-paths", action="store_true", help="Draw path of the centroid")
-parser.add_argument("--draw-only-alive", action="store_true", help="Draw only the recently matched trackers")
+parser.add_argument(
+    "--draw-unalive",
+    dest="draw_only_alive",
+    action="store_false",
+    help="By default we don't draw objects that were not recently matched. Pass this argument to draw them.",
+)
 args = parser.parse_args()
 
 mp_objectron = mp.solutions.objectron

--- a/demos/3d_track/src/demo.py
+++ b/demos/3d_track/src/demo.py
@@ -10,7 +10,7 @@ from norfair.drawing import Paths
 from utils import PixelCoordinatesProjecter, draw_3d_tracked_boxes, scaled_euclidean
 
 
-parser = argparse.ArgumentParser(description="3d-Track objects in a video.")
+parser = argparse.ArgumentParser(description="3d-Track objects in a video")
 parser.add_argument("files", type=str, nargs="+", help="Video files to process")
 parser.add_argument("--model-name", type=str, default="Shoe", help="model name ('Shoe', 'Chair', 'Cup', 'Camera')")
 parser.add_argument("--max-objects", type=int, default="2", help="Maximum number of objects at a time")
@@ -20,6 +20,7 @@ parser.add_argument("--conf-threshold", type=float, default="0.1", help="Detecto
 parser.add_argument("--distance-threshold", type=float, default="0.5", help="Distance threshold")
 parser.add_argument("--output-path", type=str, default=".", help="Output path")
 parser.add_argument("--draw-paths", action="store_true", help="Draw path of the centroid")
+parser.add_argument("--draw-only-alive", action="store_true", help="Draw only the recently matched trackers")
 args = parser.parse_args()
 
 mp_objectron = mp.solutions.objectron
@@ -50,23 +51,20 @@ with mp_objectron.Objectron(static_image_mode=True,
                         return [projecter.eye_2_pixel(points3d)[0].astype(int)]
                     path_drawer = Paths(get_points_to_draw)
 
-            detections = []
-
             # Convert the BGR image to RGB and process it with MediaPipe Objectron.
             results = objectron.process(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
             
-            if not results.detected_objects:
-                video.write(frame)
-                tracker.update(detections)
-                continue
- 
-            for detected_object in results.detected_objects:
-                points = np.array([[p.x, p.y, p.z] for p in detected_object.landmarks_3d.landmark])
-                detections.append(Detection(points=points))
-
+            detections = []
+            try:
+                for detected_object in results.detected_objects:
+                    points = np.array([[p.x, p.y, p.z] for p in detected_object.landmarks_3d.landmark])
+                    detections.append(Detection(points=points))
+            except TypeError:
+                pass
+            
             tracked_objects = tracker.update(detections)
 
-            frame = draw_3d_tracked_boxes(frame, tracked_objects, projecter=projecter.eye_2_pixel)
+            frame = draw_3d_tracked_boxes(frame, tracked_objects, projecter=projecter.eye_2_pixel, draw_only_alive=args.draw_only_alive)
             if args.draw_paths:
                 frame = path_drawer.draw(frame, tracked_objects)
 

--- a/demos/3d_track/src/demo.py
+++ b/demos/3d_track/src/demo.py
@@ -4,8 +4,10 @@ import numpy as np
 import cv2
 import mediapipe as mp
 
-from norfair import Video, Detection, Tracker, Color
+from norfair import Video, Detection, Tracker
 from norfair.distances import mean_euclidean
+
+from utils import PixelCoordinatesProjecter, draw_3d_tracked_boxes
 
 parser = argparse.ArgumentParser(description="3d-Track objects in a video.")
 parser.add_argument("files", type=str, nargs="+", help="Video files to process")
@@ -16,7 +18,6 @@ parser.add_argument("--distance-threshold", type=float, default="0.5", help="Det
 parser.add_argument("--output-path", type=str, default=".", help="Output path")
 args = parser.parse_args()
 
-mp_drawing = mp.solutions.drawing_utils
 mp_objectron = mp.solutions.objectron
 
 with mp_objectron.Objectron(static_image_mode=True,
@@ -31,31 +32,28 @@ with mp_objectron.Objectron(static_image_mode=True,
             distance_function=mean_euclidean,
             distance_threshold=args.distance_threshold,
         )
-        for image in video:
+        projecter = None
+        for frame in video:
+            if projecter is None:
+                # Set function that projects 3d objets to the pixel space
+                projecter = PixelCoordinatesProjecter(frame.shape[:2][::-1])
+
             detections = []
 
             # Convert the BGR image to RGB and process it with MediaPipe Objectron.
-            results = objectron.process(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+            results = objectron.process(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
             
-            # Draw box landmarks.
             if not results.detected_objects:
-                video.write(image)
+                video.write(frame)
                 tracker.update(detections)
                 continue
  
-            annotated_image = image.copy()
             for detected_object in results.detected_objects:
- 
                 points = np.array([[p.x, p.y, p.z] for p in detected_object.landmarks_3d.landmark])
-                detections.append(Detection(points=points, data=detected_object))
+                detections.append(Detection(points=points))
 
 
             tracked_objects = tracker.update(detections)
-            
-            for obj in tracked_objects:
-                color_spec = mp_drawing.DrawingSpec(color=Color.random(obj.id), thickness=5)
-                mp_drawing.draw_landmarks(annotated_image, obj.last_detection.data.landmarks_2d, mp_objectron.BOX_CONNECTIONS, color_spec, color_spec)
-                # mp_drawing.draw_axis(annotated_image, obj.last_detection.data.rotation, obj.last_detection.data.translation)
 
-            video.write(annotated_image)
-            
+            frame = draw_3d_tracked_boxes(frame, tracked_objects, projecter=projecter.eye_2_pixel)
+            video.write(frame)

--- a/demos/3d_track/src/utils.py
+++ b/demos/3d_track/src/utils.py
@@ -1,0 +1,157 @@
+import numpy as np
+import cv2
+from norfair import Color
+
+CONNECTED_INDEXES = [1, 2, 4, 3, 1, 5, 7, 3, 7, 8, 6, 5, 6, 2, 4, 8]
+
+class PixelCoordinatesProjecter:
+    def __init__(self, image_size, focal_length_ndc = None, principal_point_ndc = None, focal_length_pixel = None, principal_point_pixel = None):
+        '''
+        How to use?
+        - Create a PixelCoordinatesProjecter instance providing the image_size (You may provide focal length and principal points in NDC or pixel coordinates)
+        - Receive points in a 2D array in either NDC or eye coordinates (n, 3), and transform them to pixel coordinates with ndc_2_pixel or eye_2_pixel (n, 2)
+
+        Further details: 
+        http://www.songho.ca/opengl/gl_projectionmatrix.html
+        https://google.github.io/mediapipe/solutions/objectron.html#coordinate-systems
+        '''
+        
+        self.image_size = np.array(image_size)
+
+        ndc_params_is_none = all(elem is None for elem in (focal_length_ndc, principal_point_ndc))
+        pixel_params_is_none = all(elem is None for elem in (focal_length_pixel, principal_point_pixel))
+
+        if ndc_params_is_none and not pixel_params_is_none:
+            self.focal_length_pixel = focal_length_pixel
+            self.principal_point_pixel = principal_point_pixel
+            self.compute_ndc_parameters_from_pixel_parameters()
+
+        elif pixel_params_is_none and not ndc_params_is_none:
+            self.focal_length_ndc = focal_length_ndc
+            self.principal_point_ndc = principal_point_ndc
+            self.compute_pixel_parameters_from_ndc_parameters()
+
+        elif ndc_params_is_none and pixel_params_is_none:
+            self.focal_length_ndc = np.array((1.0, 1.0))
+            self.principal_point_ndc = np.array((0.0, 0.0))
+            self.compute_pixel_parameters_from_ndc_parameters()
+        else:
+            raise ValueError("You cannot provide parameters in both NDC and pixel coordinates. Choose one.")
+            
+    def compute_pixel_parameters_from_ndc_parameters(self):
+        ''' 
+        FOCAL LENGTH
+        fx_pixel = fx_ndc * image_width / 2
+        fy_pixel = fy_ndc * image_height / 2
+
+        PRINCIPAL POINT
+        px_pixel = (1-px_ndc)*image_width/2
+        py_pixel = (1-py_ndc)*image_height/2
+        '''
+        self.focal_length_pixel = self.focal_length_ndc * self.image_size / 2
+        self.principal_point_pixel = (1 - self.principal_point_ndc) * self.image_size / 2
+
+    def compute_ndc_parameters_from_pixel_parameters(self):
+        ''' 
+        FOCAL LENGTH
+        fx_ndc = fx_pixel * 2.0 / image_width
+        fy_ndc = fy_pixel * 2.0 / image_height
+
+        PRINCIPAL POINT
+        px_ndc = -px_pixel * 2.0 / image_width  + 1.0
+        py_ndc = -py_pixel * 2.0 / image_height + 1.0
+        '''
+        self.focal_length_ndc = 2 * self.focal_length_pixel / self.image_size        
+        self.principal_point_ndc = 1.0 - 2.0 * self.principal_point_pixel / self.image_size
+
+    def eye_2_ndc(self, points_eye):
+        '''
+        Takes points in eye coordinates (X, Y, Z) and convert them to NDC coordinates
+        x_ndc = -fx_ndc * X / Z + px_ndc
+        y_ndc = -fy_ndc * Y / Z + py_ndc
+        z_ndc = 1 / Z
+        '''
+
+        points_ndc = (np.ones(points_eye.shape).T / points_eye[:, 2]).T
+        points_ndc[:, :2] *= - points_eye[:, :2] *  self.focal_length_ndc
+        points_ndc[:, :2] += self.principal_point_ndc
+        return points_ndc
+
+    def eye_2_pixel(self, points_eye):
+        '''
+        Takes points in eye coordinates and project them to the pixel 2d coordinates
+        x_pixel = -fx_pixel * X / Z + px_pixel
+        y_pixel =  fy_pixel * Y / Z + py_pixel
+        '''
+        
+
+        points_pixel = (points_eye[:, :2].T / points_eye[:, 2]).T
+        points_pixel *= self.focal_length_pixel * np.array([-1, 1])
+        points_pixel += self.principal_point_pixel
+
+        return points_pixel
+
+
+    def ndc_2_pixel(self, points_ndc):
+        '''
+        Takes points in NDC coordinates and project them to the pixel 2d coordinates
+        x_pixel = (1 + x_ndc) / 2.0 * image_width
+        y_pixel = (1 - y_ndc) / 2.0 * image_height
+        '''
+
+        points_pixel = ((points_ndc[:, :2] * np.array([1, -1])) + 1) / 2
+        points_pixel *= self.image_size
+        return points_pixel
+
+
+def draw_3d_tracked_boxes(
+    frame,
+    objects,
+    projecter,
+    border_colors=None,
+    border_width=None,
+    id_size=None,
+    id_thickness=None,
+    draw_box=True,
+):
+    frame_scale = frame.shape[0] / 100
+    if border_width is None:
+        border_width = int(frame_scale * 0.5)
+    if id_size is None:
+        id_size = frame_scale / 10
+    if id_thickness is None:
+        id_thickness = int(frame_scale / 5)
+    if isinstance(border_colors, tuple):
+        border_colors = [border_colors]
+
+    for n, obj in enumerate(objects):
+        if not obj.live_points.any():
+            continue
+        if border_colors is None:
+            color = Color.random(obj.id)
+        else:
+            color = border_colors[n % len(border_colors)]
+
+        # project the points to the pixel space
+        pixel_points = projecter(obj.estimate)
+
+        # sort the points to draw the lines
+        sorted_points = np.array([pixel_points[n] for n in CONNECTED_INDEXES])
+
+        # draw box
+        if draw_box:
+            frame = cv2.polylines(frame, [sorted_points.astype(np.int32).reshape((-1, 1, 2))], isClosed = False, color = color, thickness = border_width)
+
+        if id_size > 0:
+            id_draw_position = pixel_points[0].astype(int)
+            cv2.putText(
+                frame,
+                str(obj.id),
+                tuple(id_draw_position),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                id_size,
+                color,
+                id_thickness,
+                cv2.LINE_AA,
+            )
+    return frame

--- a/demos/3d_track/src/utils.py
+++ b/demos/3d_track/src/utils.py
@@ -114,7 +114,7 @@ def draw_3d_tracked_boxes(
     id_size=None,
     id_thickness=None,
     draw_box=True,
-    draw_only_alive=False,
+    draw_only_alive=True,
 ):
     frame_scale = frame.shape[0] / 100
     if border_width is None:

--- a/norfair/drawing.py
+++ b/norfair/drawing.py
@@ -41,7 +41,6 @@ def draw_points(
             color = Color.random(abs(hash(d.label)))
         points = d.points
         points = validate_points(points)
-        points = points[:, :2]
         for point in points:
             cv2.circle(
                 frame,
@@ -102,9 +101,8 @@ def draw_tracked_objects(
             point_color = color
             id_color = color
 
-        points = obj.estimate[:, :2]
         if draw_points:
-            for point, live in zip(points, obj.live_points):
+            for point, live in zip(obj.estimate, obj.live_points):
                 if live:
                     cv2.circle(
                         frame,
@@ -115,9 +113,9 @@ def draw_tracked_objects(
                     )
 
             if draw_labels:
-                live_points = points[obj.live_points]
-                live_points = live_points.astype(int)
-                label_draw_position = np.array([min(live_points[:, 0]), min(live_points[:, 1])])
+                points = obj.estimate[obj.live_points]
+                points = points.astype(int)
+                label_draw_position = np.array([min(points[:, 0]), min(points[:, 1])])
                 label_draw_position -= radius
                 cv2.putText(
                     frame,
@@ -131,7 +129,7 @@ def draw_tracked_objects(
                 )
 
         if id_size > 0:
-            id_draw_position = centroid(points[obj.live_points])
+            id_draw_position = centroid(obj.estimate[obj.live_points])
             cv2.putText(
                 frame,
                 str(obj.id),
@@ -193,7 +191,7 @@ def draw_debug_metrics(
             else obj.estimate
         )
 
-        for point in obj.estimate[:, :2]:
+        for point in obj.estimate:
             cv2.circle(
                 frame,
                 tuple(point.astype(int)),
@@ -277,7 +275,7 @@ def draw_boxes(
             line_color = Color.random(random.randint(0, 20))
         points = d.points
         points = validate_points(points)
-        points = points[:, :2].astype(int)
+        points = points.astype(int)
         cv2.rectangle(
             frame,
             tuple(points[0, :]),
@@ -339,7 +337,7 @@ def draw_tracked_boxes(
         else:
             color = border_colors[n % len(border_colors)]
 
-        points = obj.estimate[:, :2]
+        points = obj.estimate
         if draw_box:
             points = points.astype(int)
             cv2.rectangle(
@@ -383,7 +381,8 @@ class Paths:
     def __init__(self, get_points_to_draw=None, thickness=None, color=None, radius=None, attenuation=0.01):
         if get_points_to_draw is None:
             def get_points_to_draw(points):
-                return [np.mean(np.array(points)[:2], axis=0)]
+                return [np.mean(np.array(points), axis=0)]
+
         self.get_points_to_draw = get_points_to_draw
 
         self.radius = radius

--- a/norfair/drawing.py
+++ b/norfair/drawing.py
@@ -41,6 +41,7 @@ def draw_points(
             color = Color.random(abs(hash(d.label)))
         points = d.points
         points = validate_points(points)
+        points = points[:, :2]
         for point in points:
             cv2.circle(
                 frame,
@@ -101,8 +102,9 @@ def draw_tracked_objects(
             point_color = color
             id_color = color
 
+        points = obj.estimate[:, :2]
         if draw_points:
-            for point, live in zip(obj.estimate, obj.live_points):
+            for point, live in zip(points, obj.live_points):
                 if live:
                     cv2.circle(
                         frame,
@@ -113,9 +115,9 @@ def draw_tracked_objects(
                     )
 
             if draw_labels:
-                points = obj.estimate[obj.live_points]
-                points = points.astype(int)
-                label_draw_position = np.array([min(points[:, 0]), min(points[:, 1])])
+                live_points = points[obj.live_points]
+                live_points = live_points.astype(int)
+                label_draw_position = np.array([min(live_points[:, 0]), min(live_points[:, 1])])
                 label_draw_position -= radius
                 cv2.putText(
                     frame,
@@ -129,7 +131,7 @@ def draw_tracked_objects(
                 )
 
         if id_size > 0:
-            id_draw_position = centroid(obj.estimate[obj.live_points])
+            id_draw_position = centroid(points[obj.live_points])
             cv2.putText(
                 frame,
                 str(obj.id),
@@ -191,7 +193,7 @@ def draw_debug_metrics(
             else obj.estimate
         )
 
-        for point in obj.estimate:
+        for point in obj.estimate[:, :2]:
             cv2.circle(
                 frame,
                 tuple(point.astype(int)),
@@ -275,7 +277,7 @@ def draw_boxes(
             line_color = Color.random(random.randint(0, 20))
         points = d.points
         points = validate_points(points)
-        points = points.astype(int)
+        points = points[:, :2].astype(int)
         cv2.rectangle(
             frame,
             tuple(points[0, :]),
@@ -337,7 +339,7 @@ def draw_tracked_boxes(
         else:
             color = border_colors[n % len(border_colors)]
 
-        points = obj.estimate
+        points = obj.estimate[:, :2]
         if draw_box:
             points = points.astype(int)
             cv2.rectangle(
@@ -381,8 +383,7 @@ class Paths:
     def __init__(self, get_points_to_draw=None, thickness=None, color=None, radius=None, attenuation=0.01):
         if get_points_to_draw is None:
             def get_points_to_draw(points):
-                return [np.mean(np.array(points), axis=0)]
-
+                return [np.mean(np.array(points)[:2], axis=0)]
         self.get_points_to_draw = get_points_to_draw
 
         self.radius = radius

--- a/norfair/filter.py
+++ b/norfair/filter.py
@@ -10,8 +10,9 @@ class FilterPyKalmanFilterFactory:
 
     def create_filter(self, initial_detection: np.array):
         num_points = initial_detection.shape[0]
-        dim_z = 2 * num_points
-        dim_x = 2 * 2 * num_points  # We need to accommodate for velocities
+        dim_points = initial_detection.shape[1]
+        dim_z = dim_points * num_points
+        dim_x = 2 * dim_z # We need to accommodate for velocities
 
         filter = KalmanFilter(dim_x=dim_x, dim_z=dim_z)
 
@@ -68,8 +69,9 @@ class NoFilter:
 class NoFilterFactory:
     def create_filter(self, initial_detection: np.array):
         num_points = initial_detection.shape[0]
-        dim_z = 2 * num_points  # flattened positions
-        dim_x = 2 * 2 * num_points  # We need to accommodate for velocities
+        dim_points = initial_detection.shape[1]
+        dim_z = dim_points * num_points  # flattened positions
+        dim_x = 2 * dim_z  # We need to accommodate for velocities
 
         no_filter = NoFilter(
             dim_x,
@@ -180,8 +182,9 @@ class OptimizedKalmanFilterFactory:
 
     def create_filter(self, initial_detection: np.array):
         num_points = initial_detection.shape[0]
-        dim_z = 2 * num_points  # flattened positions
-        dim_x = 2 * 2 * num_points  # We need to accommodate for velocities
+        dim_points = initial_detection.shape[1]
+        dim_z = dim_points * num_points  # flattened positions
+        dim_x = 2 * dim_z  # We need to accommodate for velocities
 
         custom_filter = OptimizedKalmanFilter(
             dim_x,

--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -11,13 +11,10 @@ from rich.table import Table
 
 def validate_points(points: np.array) -> np.array:
     # If the user is tracking only a single point, reformat it slightly.
-    if points.shape == (2,):
+    if len(points.shape) == 1:
         points = points[np.newaxis, ...]
-    elif len(points.shape) == 1:
+    elif len(points.shape) > 2:
         print_detection_error_message_and_exit(points)
-    else:
-        if points.shape[1] != 2 or len(points.shape) > 2:
-            print_detection_error_message_and_exit(points)
     return points
 
 


### PR DESCRIPTION
Allows Norfair to track n-dimensional keypoints.

When creating a `Detection` instance, the points can now be an array with shape (k, n), where k is the number of points and and n is the dimension of the points. The dimension is inferred from the number of columns of the `Detection` instances. Therefore, users don't need to provide any auxiliary parameter to specify the dimension.

Closes #112.