### PR TITLE
Avoid reseting the object count on the tracker

### DIFF
--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -115,7 +115,6 @@ class Tracker:
 
         self.distance_threshold = distance_threshold
         self.detection_threshold = detection_threshold
-        TrackedObject.count = 0
         self.reid_distance_function = reid_distance_function
         self.reid_distance_threshold = reid_distance_threshold
         self.abs_to_rel = None


### PR DESCRIPTION
Fixes #181

This change forces the tracked object count (which is used for the ids of new objects) to be shared across trackers in case multiple instances of them are needed