### PR TITLE
Version has single source of truth in pyproject.toml

### DIFF
--- a/norfair/__init__.py
+++ b/norfair/__init__.py
@@ -1,3 +1,5 @@
+import sys
+
 from .distances import *
 from .drawing import *
 from .filter import (
@@ -9,4 +11,11 @@ from .tracker import Detection, Tracker
 from .utils import get_cutout, print_objects_as_table
 from .video import Video
 
-__version__ = "2.0.0"
+if sys.version_info >= (3, 8):
+    import importlib.metadata
+
+    __version__ = importlib.metadata.version(__name__)
+elif sys.version_info < (3, 8):
+    import importlib_metadata
+
+    __version__ = importlib_metadata.version(__name__)


### PR DESCRIPTION
This makes it so we don't need any manual edits when bumping the version via `poetry version`.