### PR TITLE
Fix Python 3.6 dependency & upgrades in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ pytest = "^6.2.2"
 tox = "^3.21.4"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 name = "norfair"
 version = "2.0.0"
-description = "Lightweight Python library for real-time 2D object tracking."
+description = "Lightweight Python library for adding real-time multi-object tracking to any detector."
 license = "BSD-3-Clause"
 authors = ["Tryolabs <hello@tryolabs.com>"]
 repository = "https://github.com/tryolabs/norfair"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.6"
 filterpy = "^1.4.5"
 rich = ">=9.10.0, <13.0.0"
 opencv-python = {version = ">= 3.2.0, < 5.0.0", optional = true}


### PR DESCRIPTION
* We were specifying dependency on `python = ^3.6.1`, but this meant "Classifiers" generated by Poetry did not include Python 3.6 and therefore the package showed up as supporting Python 3.7+ only in PyPI.
* Update the description of the package (no longer 2D-only).
* Update build-backend in `pyproject.toml` to leverage latest features.