### PR TITLE
Fixed the formatting of warning strings

### DIFF
--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -74,7 +74,7 @@ def get_cutout(points, image):
 class DummyOpenCVImport:
     def __getattribute__(self, name):
         print(
-            """[bold red]Missing dependency:[/bold red] You are trying to use Norfair's video features. However, OpenCV is not installed.
+            r"""[bold red]Missing dependency:[/bold red] You are trying to use Norfair's video features. However, OpenCV is not installed.
 
 Please, make sure there is an existing installation of OpenCV or install Norfair with `pip install norfair\[video]`."""
         )
@@ -84,7 +84,7 @@ Please, make sure there is an existing installation of OpenCV or install Norfair
 class DummyMOTMetricsImport:
     def __getattribute__(self, name):
         print(
-            """[bold red]Missing dependency:[/bold red] You are trying to use Norfair's metrics features without the required dependencies.
+            r"""[bold red]Missing dependency:[/bold red] You are trying to use Norfair's metrics features without the required dependencies.
 
 Please, install Norfair with `pip install norfair\[metrics]`, or `pip install norfair\[metrics,video]` if you also want video features."""
         )


### PR DESCRIPTION
the` \[ `sequence used to scape the [ char on rich is invalid on regular strings.