### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -39,12 +39,12 @@ jobs:
   mot-metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -69,12 +69,12 @@ jobs:
     env:
       PYTHON_VERSION: 3.8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,16 @@ on:
     types: [published]
 
 jobs:
-
   #
   # Builds our package and runs the tests under supported
   # versions of Python.
   #
-  unit-test:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
 
@@ -29,18 +28,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: snok/install-poetry@v1
 
       - name: Run tests
         run: |
-          python3 -m venv ./venv
-          source venv/bin/activate
           pip install --upgrade pip
-          python --version
-          poetry install
+          pip install .
           pytest -s tests/
-  
-  mot-metric:
+
+  mot-metrics:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -51,18 +47,15 @@ jobs:
           python-version: 3.9
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: snok/install-poetry@v1
 
       - name: Run tests
         run: |
-          python3 -m venv ./venv
-          source venv/bin/activate
           pip install --upgrade pip
-          python --version
-          poetry install -E metrics
-          curl -O https://motchallenge.net/data/MOT17Labels.zip
+          pip install .[metrics]
+          wget -nc https://motchallenge.net/data/MOT17Labels.zip
           unzip MOT17Labels.zip
-          python3 tests/mot_metrics.py
+          python tests/mot_metrics.py
 
   #
   # Build & upload release to PyPI.
@@ -71,7 +64,7 @@ jobs:
   #
   release:
     runs-on: ubuntu-latest
-    needs: [unit-test, mot-metric]
+    needs: [unit-tests, mot-metrics]
     if: github.event_name == 'release'
     env:
       PYTHON_VERSION: 3.8
@@ -84,7 +77,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: snok/install-poetry@v1
 
       - name: Release to PyPI
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   #
   # Builds our package and runs the tests under supported
@@ -25,16 +29,24 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: "${{ matrix.python-version }}"
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tox
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade tox
 
       - name: Install Poetry
+        if: "matrix.python-version == '3.6'"
+        uses: snok/install-poetry@v1.1.1
+
+      - name: Install Poetry
+        if: "matrix.python-version != '3.6'"
         uses: snok/install-poetry@v1
 
       - name: Run tests
         run: |
-          pip install --upgrade pip
-          pip install .
-          pytest -s tests/
+          tox -e py
 
   mot-metrics:
     runs-on: ubuntu-latest
@@ -46,16 +58,17 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Install tox
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade tox
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
       - name: Run tests
         run: |
-          pip install --upgrade pip
-          pip install .[metrics]
-          wget -nc https://motchallenge.net/data/MOT17Labels.zip
-          unzip MOT17Labels.zip
-          python tests/mot_metrics.py
+          tox -e py39-mot
 
   #
   # Build & upload release to PyPI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,16 @@ jobs:
           pip install --upgrade tox
 
       - name: Install Poetry
-        if: "matrix.python-version == '3.6'"
-        uses: snok/install-poetry@v1.1.1
-
-      - name: Install Poetry
         if: "matrix.python-version != '3.6'"
         uses: snok/install-poetry@v1
 
+      - name: Run tests under Python 3.6
+        if: "matrix.python-version == '3.6'"
+        run: |
+          tox -e py36
+
       - name: Run tests
+        if: "matrix.python-version != '3.6'"
         run: |
           tox -e py
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,20 +31,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.7"
       - name: Setup MKDocs
         run: pip install -r docs/requirements.txt
       - name: Build Docs
-        run:  mkdocs build -d docs_site
+        run: mkdocs build -d docs_site
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
-          path: 'docs_site'
+          path: "docs_site"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-![Norfair by Tryolabs logo](docs/img/logo.svg)
+![Norfair by Tryolabs logo](https://raw.githubusercontent.com/tryolabs/norfair/master/docs/img/logo.svg)
 
 [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/tryolabs/norfair-demo)
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tryolabs/norfair/blob/master/demos/colab/colab_demo.ipynb)
 
 ![PyPI - Python Versions](https://img.shields.io/pypi/pyversions/norfair)
-![PyPI](https://img.shields.io/pypi/v/norfair?color=green)
+[![PyPI](https://img.shields.io/pypi/v/norfair?color=green)](https://pypi.org/project/norfair/)
 [![Documentation](https://img.shields.io/badge/api-reference-blue?logo=readthedocs)](https://tryolabs.github.io/norfair/)
 [![Board](https://img.shields.io/badge/project-board-blue?logo=github)](https://github.com/tryolabs/norfair/projects/1)
 ![Build status](https://github.com/tryolabs/norfair/workflows/CI/badge.svg?branch=master)
@@ -15,9 +15,9 @@ Norfair is a customizable lightweight Python library for real-time multi-object 
 
 Using Norfair, you can add tracking capabilities to any detector with just a few lines of code.
 
-| Tracking players with moving camera |   Tracking 3D objects    |
-| :---------------------------------: | :----------------------: |
-|    ![](/docs/videos/soccer.gif)     | ![](/docs/videos/3d.gif) |
+|                                           Tracking players with moving camera                                           |                                           Tracking 3D objects                                           |
+| :---------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------: |
+| ![Tracking players in a soccer match](https://raw.githubusercontent.com/tryolabs/norfair/master/docs/videos/soccer.gif) | ![Tracking objects in 3D](https://raw.githubusercontent.com/tryolabs/norfair/master/docs/videos/3d.gif) |
 
 ## Features
 
@@ -72,28 +72,28 @@ We provide several examples of how Norfair can be used to add tracking capabilit
 
 Most tracking demos are showcased with vehicles and pedestrians, but the detectors are generally trained with many more classes from the [COCO dataset](https://cocodataset.org/).
 
-1. [YOLOv7](demos/yolov7): tracking object centroids or bounding boxes.
-2. [YOLOv5](demos/yolov5): tracking object centroids or bounding boxes.
-3. [YOLOv4](demos/yolov4): tracking object centroids.
-4. [Detectron2](demos/detectron2): tracking object centroids.
-5. [AlphaPose](demos/alphapose): tracking human keypoints (pose estimation) and inserting Norfair into a complex existing pipeline using.
-6. [OpenPose](demos/openpose): tracking human keypoints.
+1. [YOLOv7](https://github.com/tryolabs/norfair/tree/master/demos/yolov7): tracking object centroids or bounding boxes.
+2. [YOLOv5](https://github.com/tryolabs/norfair/tree/master/demos/yolov5): tracking object centroids or bounding boxes.
+3. [YOLOv4](https://github.com/tryolabs/norfair/tree/master/demos/yolov4): tracking object centroids.
+4. [Detectron2](https://github.com/tryolabs/norfair/tree/master/demos/detectron2): tracking object centroids.
+5. [AlphaPose](https://github.com/tryolabs/norfair/tree/master/demos/alphapose): tracking human keypoints (pose estimation) and inserting Norfair into a complex existing pipeline using.
+6. [OpenPose](https://github.com/tryolabs/norfair/tree/master/demos/openpose): tracking human keypoints.
 
 ### Advanced features
 
-1. [Speed up pose estimation by extrapolating detections](demos/openpose) using [OpenPose](https://github.com/CMU-Perceptual-Computing-Lab/openpose).
-2. [Track both bounding boxes and human keypoints](demos/keypoints_bounding_boxes) (multi-class), unifying the detections from a YOLO model and OpenPose.
-3. [Re-identification (ReID)](demos/reid) of tracked objects using appearance embeddings. This is a good starting point for scenarios with a lot of occlusion, in which the Kalman filter alone would struggle.
-4. [Accurately track objects even if the camera is moving](demos/camera_motion), by estimating camera motion potentially accounting for pan, tilt, rotation, movement in any direction, and zoom.
-5. [Track points in 3D](demos/3d_track), using [MediaPipe Objectron](https://google.github.io/mediapipe/solutions/objectron.html).
-6. [Small object tracking](demos/sahi), using [SAHI: Slicing Aided Hyper Inference](https://github.com/obss/sahi).
+1. [Speed up pose estimation by extrapolating detections](https://github.com/tryolabs/norfair/tree/master/demos/openpose) using [OpenPose](https://github.com/CMU-Perceptual-Computing-Lab/openpose).
+2. [Track both bounding boxes and human keypoints](https://github.com/tryolabs/norfair/tree/master/demos/keypoints_bounding_boxes) (multi-class), unifying the detections from a YOLO model and OpenPose.
+3. [Re-identification (ReID)](https://github.com/tryolabs/norfair/tree/master/demos/reid) of tracked objects using appearance embeddings. This is a good starting point for scenarios with a lot of occlusion, in which the Kalman filter alone would struggle.
+4. [Accurately track objects even if the camera is moving](https://github.com/tryolabs/norfair/tree/master/demos/camera_motion), by estimating camera motion potentially accounting for pan, tilt, rotation, movement in any direction, and zoom.
+5. [Track points in 3D](https://github.com/tryolabs/norfair/tree/master/demos/3d_track), using [MediaPipe Objectron](https://google.github.io/mediapipe/solutions/objectron.html).
+6. [Tracking of small objects](https://github.com/tryolabs/norfair/tree/master/demos/sahi), using [SAHI: Slicing Aided Hyper Inference](https://github.com/obss/sahi).
 
 ### Benchmarking and profiling
 
-1. [Kalman filter and distance function profiling](demos/profiling) using [TRT pose estimator](https://github.com/NVIDIA-AI-IOT/trt_pose).
-2. Computation of [MOT17](https://motchallenge.net/data/MOT17/) scores using [motmetrics4norfair](demos/motmetrics4norfair).
+1. [Kalman filter and distance function profiling](https://github.com/tryolabs/norfair/tree/master/demos/profiling) using [TRT pose estimator](https://github.com/NVIDIA-AI-IOT/trt_pose).
+2. Computation of [MOT17](https://motchallenge.net/data/MOT17/) scores using [motmetrics4norfair](https://github.com/tryolabs/norfair/tree/master/demos/motmetrics4norfair).
 
-![Norfair OpenPose Demo](docs/videos/openpose_skip_3_frames.gif)
+![Norfair OpenPose Demo](https://raw.githubusercontent.com/tryolabs/norfair/master/docs/videos/openpose_skip_3_frames.gif)
 
 ## How it works
 
@@ -108,7 +108,7 @@ The following is an example of a particularly simple distance function calculati
 
 As an example we use [Detectron2](https://github.com/facebookresearch/detectron2) to get the single point detections to use with this distance function. We just use the centroids of the bounding boxes it produces around cars as our detections, and get the following results.
 
-![Tracking cars with Norfair](docs/videos/traffic.gif)
+![Tracking cars with Norfair](https://raw.githubusercontent.com/tryolabs/norfair/master/docs/videos/traffic.gif)
 
 On the left you can see the points we get from Detectron2, and on the right how Norfair tracks them assigning a unique identifier through time. Even a straightforward distance function like this one can work when the tracking needed is simple.
 
@@ -201,4 +201,4 @@ For citations in academic publications, please export your desired citation form
 
 ## License
 
-Copyright © 2022, [Tryolabs](https://tryolabs.com). Released under the [BSD 3-Clause](LICENSE).
+Copyright © 2022, [Tryolabs](https://tryolabs.com). Released under the [BSD 3-Clause](https://github.com/tryolabs/norfair/blob/master/LICENSE).

--- a/poetry.lock
+++ b/poetry.lock
@@ -732,7 +732,7 @@ video = ["opencv-python"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "f2d94dce855f38da3c73efb6b1fe3df680fbba24ef7a5e372d68315198f2465e"
+content-hash = "7916154a715fa71f7c5571c787c5af4d9cb7b90d7aabcff4146f1ad61b0de7e5"
 
 [metadata.files]
 appdirs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -601,6 +601,19 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 numpy = ">=1.14.5"
+
+[[package]]
+name = "setuptools"
+version = "59.6.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
+testing = ["flake8-2020", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
+
 [[package]]
 name = "six"
 version = "1.16.0"
@@ -719,7 +732,7 @@ video = ["opencv-python"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "a42a96490a7be11f64c999f33439d56d52bda259d615671747301fc6660a0b54"
+content-hash = "f2d94dce855f38da3c73efb6b1fe3df680fbba24ef7a5e372d68315198f2465e"
 
 [metadata.files]
 appdirs = [
@@ -1243,6 +1256,10 @@ scipy = [
     {file = "scipy-1.5.4-cp39-cp39-win32.whl", hash = "sha256:d84cadd7d7998433334c99fa55bcba0d8b4aeff0edb123b2a1dfcface538e474"},
     {file = "scipy-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:cc1f78ebc982cd0602c9a7615d878396bec94908db67d4ecddca864d049112f2"},
     {file = "scipy-1.5.4.tar.gz", hash = "sha256:4a453d5e5689de62e5d38edf40af3f17560bfd63c9c5bd228c18c1f99afa155b"},
+]
+setuptools = [
+    {file = "setuptools-59.6.0-py3-none-any.whl", hash = "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"},
+    {file = "setuptools-59.6.0.tar.gz", hash = "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,7 +25,7 @@ wrapt = ">=1.11,<1.14"
 name = "atomicwrites"
 version = "1.4.1"
 description = "Atomic file writes."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -33,7 +33,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 
@@ -147,31 +147,6 @@ numpy = "*"
 scipy = "*"
 
 [[package]]
-name = "flake8"
-version = "2.3.0"
-description = "the modular source code checker: pep8, pyflakes and co"
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-mccabe = ">=0.2.1"
-pep8 = ">=1.5.7"
-pyflakes = ">=0.8.1"
-
-[[package]]
-name = "flake8-import-order"
-version = "0.18.1"
-description = "Flake8 and pylama plugin that checks the ordering of import statements."
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-pycodestyle = "*"
-setuptools = "*"
-
-[[package]]
 name = "importlib-metadata"
 version = "4.8.3"
 description = "Read metadata from Python packages"
@@ -207,7 +182,7 @@ testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)",
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -261,25 +236,21 @@ python-dateutil = ">=2.1"
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
 [[package]]
 name = "motmetrics"
-version = "1.2.0"
+version = "1.2.5"
 description = "Metrics for multiple object tracker benchmarking."
 category = "main"
 optional = true
 python-versions = "*"
 
 [package.dependencies]
-flake8 = "*"
-flake8-import-order = "*"
 numpy = ">=1.12.1"
 pandas = ">=0.23.1"
-pytest = "*"
-pytest-benchmark = "*"
 scipy = ">=0.19.0"
 xmltodict = ">=0.12.0"
 
@@ -362,7 +333,7 @@ numpy = [
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -394,14 +365,6 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
-name = "pep8"
-version = "1.7.1"
-description = "Python style guide checker"
-category = "main"
-optional = true
-python-versions = "*"
-
-[[package]]
 name = "Pillow"
 version = "8.4.0"
 description = "Python Imaging Library (Fork)"
@@ -425,7 +388,7 @@ test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock 
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -440,33 +403,9 @@ testing = ["pytest", "pytest-benchmark"]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "py-cpuinfo"
-version = "8.0.0"
-description = "Get CPU info with pure Python 2 & 3"
-category = "main"
-optional = true
-python-versions = "*"
-
-[[package]]
-name = "pycodestyle"
-version = "2.9.1"
-description = "Python style guide checker"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[[package]]
-name = "pyflakes"
-version = "2.5.0"
-description = "passive checker of Python programs"
-category = "main"
-optional = true
-python-versions = ">=3.6"
 
 [[package]]
 name = "Pygments"
@@ -511,7 +450,7 @@ diagrams = ["jinja2", "railroad-diagrams"]
 name = "pytest"
 version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -528,23 +467,6 @@ toml = "*"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
-
-[[package]]
-name = "pytest-benchmark"
-version = "3.4.1"
-description = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
-category = "main"
-optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[package.dependencies]
-py-cpuinfo = "*"
-pytest = ">=3.8"
-
-[package.extras]
-aspect = ["aspectlib"]
-elasticsearch = ["elasticsearch"]
-histogram = ["pygal", "pygaljs"]
 
 [[package]]
 name = "python-dateutil"
@@ -606,7 +528,7 @@ numpy = ">=1.14.5"
 name = "setuptools"
 version = "59.6.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -626,7 +548,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -726,13 +648,13 @@ docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [extras]
-metrics = ["motmetrics"]
+metrics = ["motmetrics", "importlib-metadata"]
 video = ["opencv-python"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "7916154a715fa71f7c5571c787c5af4d9cb7b90d7aabcff4146f1ad61b0de7e5"
+content-hash = "6bf4f02883943768eea21d398ba93277f3c9bb80be6d62dbc25ad418fbf99fb0"
 
 [metadata.files]
 appdirs = [
@@ -783,14 +705,6 @@ filelock = [
 ]
 filterpy = [
     {file = "filterpy-1.4.5.zip", hash = "sha256:4f2a4d39e4ea601b9ab42b2db08b5918a9538c168cff1c6895ae26646f3d73b1"},
-]
-flake8 = [
-    {file = "flake8-2.3.0-py2.py3-none-any.whl", hash = "sha256:c99cc9716d6655d9c8bcb1e77632b8615bf0abd282d7abd9f5c2148cad7fc669"},
-    {file = "flake8-2.3.0.tar.gz", hash = "sha256:5ee1a43ccd0716d6061521eec6937c983efa027793013e572712c4da55c7c83e"},
-]
-flake8-import-order = [
-    {file = "flake8-import-order-0.18.1.tar.gz", hash = "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"},
-    {file = "flake8_import_order-0.18.1-py2.py3-none-any.whl", hash = "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
@@ -918,8 +832,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 motmetrics = [
-    {file = "motmetrics-1.2.0-py3-none-any.whl", hash = "sha256:78be33a951fe17b4a1b2c17b235b769920b700345b83e46d4b436f3efaf54d9f"},
-    {file = "motmetrics-1.2.0.tar.gz", hash = "sha256:7328d8468c948400b38fcc212f3e448bc1f2fdfc727e170d85a029e49f1cdbc6"},
+    {file = "motmetrics-1.2.5-py3-none-any.whl", hash = "sha256:44052ccc7fa691df441ae420d39378f9173e31bdee8fb42474a58ea79f9f7c1c"},
+    {file = "motmetrics-1.2.5.tar.gz", hash = "sha256:3a777d5ab611cee008ae2c1acc39c7048d2b0b2eafed0f0f1ae473f35ebe34b9"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -1038,10 +952,6 @@ pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
-pep8 = [
-    {file = "pep8-1.7.1-py2.py3-none-any.whl", hash = "sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee"},
-    {file = "pep8-1.7.1.tar.gz", hash = "sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374"},
-]
 Pillow = [
     {file = "Pillow-8.4.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d"},
     {file = "Pillow-8.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6"},
@@ -1097,17 +1007,6 @@ py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
-py-cpuinfo = [
-    {file = "py-cpuinfo-8.0.0.tar.gz", hash = "sha256:5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5"},
-]
-pycodestyle = [
-    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
-    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
-]
-pyflakes = [
-    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
-    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
-]
 Pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
     {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
@@ -1123,10 +1022,6 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
-]
-pytest-benchmark = [
-    {file = "pytest-benchmark-3.4.1.tar.gz", hash = "sha256:40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47"},
-    {file = "pytest_benchmark-3.4.1-py2.py3-none-any.whl", hash = "sha256:36d2b08c4882f6f997fd3126a3d6dfd70f3249cde178ed8bbc0b73db7c20f809"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,21 +16,21 @@ classifiers = [
 python = "^3.6.1"
 filterpy = "^1.4.5"
 rich = ">=9.10.0, <13.0.0"
-opencv-python = {version = ">= 3.2.0, < 5.0.0", optional = true}
-motmetrics = {version = "1.2.0", optional = true}
+opencv-python = { version = ">= 3.2.0, < 5.0.0", optional = true }
+motmetrics = { version = "1.2.0", optional = true }
 
 [tool.poetry.extras]
 metrics = ["motmetrics"]
 video = ["opencv-python"]
 
 [tool.poetry.group.test.dependencies]
-pylint = "^2.6.0"
-pytest = "^6.2.2"
-tox = "^3.21.4"
+pylint = "^2.12.0"
+pytest = "^6.2.5"
+tox = "^3.26.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^20.8b1"
-isort = "^5.7.0"
+isort = "^5.10.1"
 
 [build-system]
 # Need >= 1.1.0a6 to work on Python 3.6 or we get

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,33 @@ license = "BSD-3-Clause"
 authors = ["Tryolabs <hello@tryolabs.com>"]
 repository = "https://github.com/tryolabs/norfair"
 readme = "README.md"
+keywords = [
+    "tracking",
+    "object-detection",
+    "object-tracking",
+    "kalman-filter",
+    "pose-estimation",
+    "re-identification",
+    "multi-object-tracking",
+    "re-id",
+    "tracking-algorithm",
+    "deepsort",
+    "video-tracking",
+    "video-inference-loop"
+]
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
-    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.6",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Image Recognition",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Multimedia :: Video"
 ]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,11 @@ python = "^3.6.1"
 filterpy = "^1.4.5"
 rich = ">=9.10.0, <13.0.0"
 opencv-python = { version = ">= 3.2.0, < 5.0.0", optional = true }
-motmetrics = { version = "1.2.0", optional = true }
+motmetrics = { version = "1.2.5", optional = true }
+importlib-metadata = { version = "4.8.3", python = "<3.8" }
 
 [tool.poetry.extras]
-metrics = ["motmetrics"]
+metrics = ["motmetrics", "importlib-metadata"]
 video = ["opencv-python"]
 
 [tool.poetry.group.test.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,20 @@ motmetrics = {version = "1.2.0", optional = true}
 metrics = ["motmetrics"]
 video = ["opencv-python"]
 
-[tool.poetry.dev-dependencies]
-black = "^20.8b1"
-isort = "^5.7.0"
+[tool.poetry.group.test.dependencies]
 pylint = "^2.6.0"
 pytest = "^6.2.2"
 tox = "^3.21.4"
 
+[tool.poetry.group.dev.dependencies]
+black = "^20.8b1"
+isort = "^5.7.0"
+
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+# Need >= 1.1.0a6 to work on Python 3.6 or we get
+# "The Poetry configuration is invalid" because of dependency
+# groups. Otherwise can use >= 1.0.0.
+requires = ["poetry-core>=1.1.0a6"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39}
+envlist = py{36,37,38,39,310}
 
 [testenv]
 allowlist_externals = poetry

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,17 @@ commands =
     poetry install --no-root --only=test -v
     poetry run pytest -s tests/
 
+[testenv:py36]
+description = run unit tests under Python 3.6
+commands =
+    ; Just install Pytest without Poetry.
+    ; Latest Poetry doesn't support Python 3.6.
+    ; If using earlier Poetry, won't work because we are using
+    ; dependency groups. So just do it without Poetry until
+    ; support for 3.6 is removed.
+    pip install pytest==6.2.5
+    pytest -s tests/
+
 [testenv:py{36,37,38,39,310}]
 description = run unit tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39,310},py39-mot
+envlist = py{36,37,38,39,310},mot-py39
 
 [testenv]
 allowlist_externals = poetry
@@ -33,7 +33,7 @@ commands =
 [testenv:py{36,37,38,39,310}]
 description = run unit tests
 
-[testenv:py39-mot]
+[testenv:mot-py{36,37,38,39,310}]
 description = compute MOT metrics for evaluation
 extras = metrics
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39,310}
+envlist = py{36,37,38,39,310},py39-mot
 
 [testenv]
 allowlist_externals = poetry
                       unzip
                       wget
-
-[testenv:py{36,37,38,39,310}]
-description = run unit tests
+commands_pre =
+    python --version
 commands =
     ; Install only test dependencies with poetry.
     ; This is because installing everything from the lock will likely
@@ -19,6 +18,9 @@ commands =
     ; not that bad).
     poetry install --no-root --only=test -v
     poetry run pytest -s tests/
+
+[testenv:py{36,37,38,39,310}]
+description = run unit tests
 
 [testenv:py39-mot]
 description = compute MOT metrics for evaluation

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39,310},py39-mot
+envlist = py{36,37,38,39,310}
 
 [testenv]
 allowlist_externals = poetry

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,36 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39,310}
+envlist = py{36,37,38,39,310},py39-mot
 
 [testenv]
 allowlist_externals = poetry
                       unzip
                       wget
+
+[testenv:py{36,37,38,39,310}]
+description = run unit tests
 commands =
-    pip install .[metrics]
+    ; Install only test dependencies with poetry.
+    ; This is because installing everything from the lock will likely
+    ; not work under Python 3.10 (difficult or impossible to install
+    ; the locked version of numpy -- 1.19.5).
+    ; So, until we stop supporting 3.6, run our CI with different
+    ; versions of the packages under different Python versions (it's
+    ; not that bad).
+    poetry install --no-root --only=test -v
     poetry run pytest -s tests/
+
+[testenv:py39-mot]
+description = compute MOT metrics for evaluation
+extras = metrics
+commands =
     ; Download the needed files to perform the MOT metrics test
     wget -nc https://motchallenge.net/data/MOT17Labels.zip
     unzip -n MOT17Labels.zip
     poetry run python tests/mot_metrics.py
+
+[testenv:docs]
+description = invoke mkdocs to build the HTML docs
+commands =
+    pip install -r docs/requirements.txt
+    mkdocs build -d docs_site


### PR DESCRIPTION
With this PR, Norfair supports Python 3.6 - 3.10.

* There are no code changes in Norfair itself. It's mostly around tooling so tests (CI) can run in all Python versions.
* `tox` works for running the tests locally, and Github Actions leverage `tox` so there is no duplicate code.
* Add more information to PyPI package for better discoverability. 
* Fix README so it displays better in PyPI (GIFs > 10 MB don't load, though) and links work (made them absolute).

Python 3.6 support is a pain to maintain, and therefore next will be the last release to support it.
