### PR TITLE
Do not store past detections by default.

### DIFF
--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -80,7 +80,7 @@ class Tracker:
         pointwise_hit_counter_max: int = 4,
         detection_threshold: float = 0,
         filter_factory: FilterFactory = OptimizedKalmanFilterFactory(),
-        past_detections_length: int = 4,
+        past_detections_length: int = 0,
         reid_distance_function: Optional[
             Callable[["TrackedObject", "TrackedObject"], float]
         ] = None,


### PR DESCRIPTION
Until now, the default value for `past_detections_length` was `4`. This meant that even if you don't use the past detections in your workflow, Norfair is still storing them, making unnecessary operations and potentially using a great amount of memory for storing embeddings or image crops. 

We now set the default value of `past_detections_length` to `0`. If the user wants to use the `TrackedObject`'s past detections when matching, it must be specified when initiating the `Tracker` instance.