### PR TITLE
New vectorized distance functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Using Norfair, you can add tracking capabilities to any detector with just a few
 
 - Supports moving camera, re-identification with appearance embeddings, and n-dimensional object tracking (see [Advanced features](#advanced-features)).
 
-- The function used to calculate the distance between tracked objects and detections is defined by the user, enabling the implementation of different tracking strategies.
+- Norfair provides several predefined distance functions to compare tracked objects and detections. The distance functions can also be defined by the user, enabling the implementation of different tracking strategies.
 
 - Fast. The only thing bounding inference speed will be the detection network feeding detections to Norfair.
 
@@ -98,9 +98,9 @@ Most tracking demos are showcased with vehicles and pedestrians, but the detecto
 
 ## How it works
 
-Norfair works by estimating the future position of each point based on its past positions. It then tries to match these estimated positions with newly detected points provided by the detector. For this matching to occur, Norfair can rely on any distance function specified by the user of the library. Therefore, each object tracker can be made as simple or as complex as needed.
+Norfair works by estimating the future position of each point based on its past positions. It then tries to match these estimated positions with newly detected points provided by the detector. For this matching to occur, Norfair can rely on any distance function. There are some predefined distances already integrated in Norfair, and the users can also define their own custom distances. Therefore, each object tracker can be made as simple or as complex as needed.
 
-The following is an example of a particularly simple distance function calculating the Euclidean distance between tracked objects and detections. This is possibly the simplest distance function you could use in Norfair, as it uses just one single point per detection/object.
+The following is an example of a particularly simple distance function calculating the Euclidean distance between tracked objects and detections. This distance is already integrated in Norfair and can be used simply by setting the string `"euclidean"` when building the tracker. This is possibly the simplest distance function you could use in Norfair, as it uses just one single point per detection/object.
 
 ```python
  def euclidean_distance(detection, tracked_object):
@@ -132,7 +132,7 @@ detector = DefaultPredictor(cfg)
 
 # Norfair
 video = Video(input_path="video.mp4")
-tracker = Tracker(distance_function=euclidean_distance, distance_threshold=20)
+tracker = Tracker(distance_function="euclidean", distance_threshold=20)
 
 for frame in video:
     detections = detector(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))

--- a/README.md
+++ b/README.md
@@ -100,13 +100,6 @@ Most tracking demos are showcased with vehicles and pedestrians, but the detecto
 
 Norfair works by estimating the future position of each point based on its past positions. It then tries to match these estimated positions with newly detected points provided by the detector. For this matching to occur, Norfair can rely on any distance function. There are some predefined distances already integrated in Norfair, and the users can also define their own custom distances. Therefore, each object tracker can be made as simple or as complex as needed.
 
-The following is an example of a particularly simple distance function calculating the Euclidean distance between tracked objects and detections. This distance is already integrated in Norfair and can be used simply by setting the string `"euclidean"` when building the tracker. This is possibly the simplest distance function you could use in Norfair, as it uses just one single point per detection/object.
-
-```python
- def euclidean_distance(detection, tracked_object):
-     return np.linalg.norm(detection.points - tracked_object.estimate)
-```
-
 As an example we use [Detectron2](https://github.com/facebookresearch/detectron2) to get the single point detections to use with this distance function. We just use the centroids of the bounding boxes it produces around cars as our detections, and get the following results.
 
 ![Tracking cars with Norfair](https://raw.githubusercontent.com/tryolabs/norfair/master/docs/videos/traffic.gif)

--- a/demos/3d_track/Dockerfile
+++ b/demos/3d_track/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip && \
-    pip install mediapipe==0.8.10.1 && \
+    pip install mediapipe==0.8.11 && \
     pip install opencv-python==4.5.5.64
 
 RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair

--- a/demos/alphapose/writer.py
+++ b/demos/alphapose/writer.py
@@ -22,7 +22,7 @@ DEFAULT_VIDEO_SAVE_OPT = {
 EVAL_JOINTS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 
 detection_threshold = 0.2
-keypoint_dist_threshold = None
+keypoint_dist_threshold = 10
 
 
 def keypoints_distance(detected_pose, tracked_pose):
@@ -262,7 +262,6 @@ class DataWriter:
 
                 final_result.append(result)
                 if self.opt.save_img or self.save_video or self.opt.vis:
-
                     img = orig_img.copy()
                     global keypoint_dist_threshold
                     keypoint_dist_threshold = img.shape[0] / 30

--- a/demos/camera_motion/src/demo.py
+++ b/demos/camera_motion/src/demo.py
@@ -224,7 +224,7 @@ def run():
         )
 
         tracker = Tracker(
-            distance_function="frobenius",
+            distance_function="euclidean",
             detection_threshold=args.confidence_threshold,
             distance_threshold=args.distance_threshold,
             initialization_delay=args.initialization_delay,

--- a/demos/detectron2/src/demo.py
+++ b/demos/detectron2/src/demo.py
@@ -20,7 +20,7 @@ detector = DefaultPredictor(cfg)
 
 # Norfair
 video = Video(input_path=args.file)
-tracker = Tracker(distance_function="frobenius", distance_threshold=20)
+tracker = Tracker(distance_function="euclidean", distance_threshold=20)
 
 for frame in video:
     detections = detector(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))

--- a/demos/mmdetection/mmdetection_cars.py
+++ b/demos/mmdetection/mmdetection_cars.py
@@ -3,8 +3,6 @@ from mmdet.apis import inference_detector, init_detector
 from mmdet.core import get_classes
 
 from norfair import Detection, Tracker, Video, draw_tracked_objects
-from norfair.distances import frobenius
-from norfair.tracker import TrackedObject
 
 #
 # MMDetection setup
@@ -27,7 +25,7 @@ VEHICLE_CLASSES = [
 
 
 tracker = Tracker(
-    distance_function=frobenius, distance_threshold=20, detection_threshold=0.6
+    distance_function="euclidean", distance_threshold=20, detection_threshold=0.6
 )
 
 

--- a/demos/mmdetection/src/demo.py
+++ b/demos/mmdetection/src/demo.py
@@ -5,8 +5,6 @@ from mmdet.apis import inference_detector, init_detector
 from mmdet.core import get_classes
 
 from norfair import Detection, Tracker, Video, draw_tracked_objects
-from norfair.distances import frobenius
-from norfair.tracker import TrackedObject
 
 parser = argparse.ArgumentParser(description="Track human poses in a video.")
 parser.add_argument("files", type=str, nargs="+", help="Video files to process")
@@ -34,7 +32,7 @@ VEHICLE_CLASSES = [
 for input_path in args.files:
 
     tracker = Tracker(
-        distance_function=frobenius, distance_threshold=20, detection_threshold=0.6
+        distance_function="euclidean", distance_threshold=20, detection_threshold=0.6
     )
 
     video = Video(input_path=input_path, output_path=args.output_path)

--- a/demos/motmetrics4norfair/src/motmetrics4norfair.py
+++ b/demos/motmetrics4norfair/src/motmetrics4norfair.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from norfair import drawing, metrics, Tracker, video
 from norfair.camera_motion import MotionEstimator
-from norfair.distances import iou
 from norfair.filter import FilterPyKalmanFilterFactory
 
 DETECTION_THRESHOLD = 0.5
@@ -103,7 +102,7 @@ for input_path in sequences_paths:
     )
 
     tracker = Tracker(
-        distance_function=iou,
+        distance_function="iou_opt",
         distance_threshold=DISTANCE_THRESHOLD,
         detection_threshold=DETECTION_THRESHOLD,
         pointwise_hit_counter_max=POINTWISE_HIT_COUNTER_MAX,

--- a/demos/reid/src/demo.py
+++ b/demos/reid/src/demo.py
@@ -12,10 +12,6 @@ from norfair import Tracker, Video, draw_points, draw_tracked_objects, get_cutou
 from norfair.filter import OptimizedKalmanFilterFactory
 
 
-def distance_func(detection, tracked_object):
-    return np.linalg.norm(detection.points - tracked_object.estimate)
-
-
 def embedding_distance(matched_not_init_trackers, unmatched_trackers):
     snd_embedding = unmatched_trackers.last_detection.embedding
 
@@ -50,19 +46,16 @@ def main(
     if disable_reid:
         tracker = Tracker(
             initialization_delay=1,
-            distance_function=distance_func,
+            distance_function="euclidean",
             hit_counter_max=10,
             filter_factory=OptimizedKalmanFilterFactory(),
             distance_threshold=50,
             past_detections_length=5,
-            # reid_distance_function=embedding_distance,
-            # reid_distance_threshold=0.5,
-            # reid_hit_counter_max=500,
         )
     else:
         tracker = Tracker(
             initialization_delay=1,
-            distance_function=distance_func,
+            distance_function="euclidean",
             hit_counter_max=10,
             filter_factory=OptimizedKalmanFilterFactory(),
             distance_threshold=50,

--- a/demos/sahi/src/demo.py
+++ b/demos/sahi/src/demo.py
@@ -6,7 +6,6 @@ from sahi.prediction import PredictionResult
 from utils import create_arg_parser, obtain_detection_model
 
 from norfair import Detection, Tracker, Video, draw_boxes, draw_tracked_boxes
-from norfair.distances import iou
 from norfair.filter import OptimizedKalmanFilterFactory
 
 
@@ -48,7 +47,7 @@ def main(
 
     tracker = Tracker(
         initialization_delay=initialization_delay,
-        distance_function=iou,
+        distance_function="iou",
         hit_counter_max=hit_counter_max,
         filter_factory=OptimizedKalmanFilterFactory(),
         distance_threshold=distance_threshold,

--- a/demos/yolopv2/src/demo.py
+++ b/demos/yolopv2/src/demo.py
@@ -96,7 +96,7 @@ def detect():
 
     # Norfair Tracker init
     tracker = Tracker(
-        distance_function=iou,
+        distance_function="iou",
         distance_threshold=0.7,
     )
 

--- a/demos/yolov4/Dockerfile
+++ b/demos/yolov4/Dockerfile
@@ -19,6 +19,6 @@ WORKDIR /demo
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair[metrics]
+RUN pip install git+https://github.com/tryolabs/norfair.git@master
 
 WORKDIR /demo/src

--- a/demos/yolov4/Dockerfile
+++ b/demos/yolov4/Dockerfile
@@ -19,6 +19,6 @@ WORKDIR /demo
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master
+RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair[metrics]
 
 WORKDIR /demo/src

--- a/demos/yolov4/requirements.txt
+++ b/demos/yolov4/requirements.txt
@@ -1,1 +1,2 @@
 opencv-python==4.6.0.66
+importlib-metadata==4.8.3

--- a/demos/yolov4/src/demo.py
+++ b/demos/yolov4/src/demo.py
@@ -62,7 +62,7 @@ model = YOLO(
 for input_path in args.files:
     video = Video(input_path=input_path, output_path=args.output_path)
     tracker = Tracker(
-        distance_function="frobenius",
+        distance_function="euclidean",
         distance_threshold=max_distance_between_points,
     )
 

--- a/demos/yolov5/src/demo.py
+++ b/demos/yolov5/src/demo.py
@@ -6,7 +6,6 @@ import torch
 
 import norfair
 from norfair import Detection, Paths, Tracker, Video
-from norfair.distances import frobenius, iou
 
 DISTANCE_THRESHOLD_BBOX: float = 0.7
 DISTANCE_THRESHOLD_CENTROID: int = 30
@@ -127,7 +126,7 @@ model = YOLO(args.model_name, device=args.device)
 for input_path in args.files:
     video = Video(input_path=input_path)
 
-    distance_function = iou if args.track_points == "bbox" else frobenius
+    distance_function = "iou_opt" if args.track_points == "bbox" else "euclidean"
     distance_threshold = (
         DISTANCE_THRESHOLD_BBOX
         if args.track_points == "bbox"

--- a/demos/yolov7/src/demo.py
+++ b/demos/yolov7/src/demo.py
@@ -8,7 +8,6 @@ import torchvision.ops.boxes as bops
 
 import norfair
 from norfair import Detection, Paths, Tracker, Video
-from norfair.distances import frobenius, iou
 
 DISTANCE_THRESHOLD_BBOX: float = 0.7
 DISTANCE_THRESHOLD_CENTROID: int = 30
@@ -137,7 +136,7 @@ model = YOLO(args.detector_path, device=args.device)
 for input_path in args.files:
     video = Video(input_path=input_path)
 
-    distance_function = iou if args.track_points == "bbox" else frobenius
+    distance_function = "iou_opt" if args.track_points == "bbox" else "euclidean"
 
     distance_threshold = (
         DISTANCE_THRESHOLD_BBOX

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,7 +44,7 @@ from norfair import Detection, Tracker, Video, draw_tracked_objects
 
 detector = MyDetector()  # Set up a detector
 video = Video(input_path="video.mp4")
-tracker = Tracker(distance_function="frobenius", distance_threshold=100)
+tracker = Tracker(distance_function="euclidean", distance_threshold=100)
 
 for frame in video:
    detections = detector(frame)
@@ -76,11 +76,11 @@ After inspecting the detections you might find issues with the tracking, several
 - Objects take **too long to start**, this can have multiple causes:
     - `initialization_delay` is too big on the Tracker. Makes the TrackedObject stay on initializing for too long, `3` is usually a good value to start with.
     - `distance_threshold` is too small on the Tracker. Prevents the Detections to be matched with the correct TrackedObject. The best value depends on the distance used.
-    - Incorrect `distance_function` on the Tracker. Some distances might not be valid in some cases, for instance, if using IoU but the objects in your video move so quickly that there is never an overlap between the detections of consecutive frames. Try different distances, `frobenius` or `create_normalized_mean_euclidean_distance` are good starting points.
+    - Incorrect `distance_function` on the Tracker. Some distances might not be valid in some cases, for instance, if using IoU but the objects in your video move so quickly that there is never an overlap between the detections of consecutive frames. Try different distances, `euclidean` or `create_normalized_mean_euclidean_distance` are good starting points.
 - Objects take **too long to disappear**. Lower `hit_counter_max` on the Tracker.
 - Points or bounding boxes **jitter too much**. Increase `R` (measurement error) or lower `Q` (estimate or process error) on the `OptimizedKalmanFilterFactory` or `FilterPyKalmanFilterFactory`. This makes the Kalman Filter put less weight on the measurements and trust more on the estimate, stabilizing the result.
 - **Camera motion** confuses the Tracker. If the camera moves, the apparent movement of objects can become too erratic for the Tracker. Use `MotionEstimator`.
 - **Incorrect matches** between Detections and TrackedObjects, a couple of scenarios can cause this:
     - `distance_threshold` is too big so the Tracker matches Detections to TrackedObjects that are simply too far. Lower the threshold until you fix the error, the correct value will depend on the distance function that you're using.
-    - Mismatches when objects overlap. In this case, tracking becomes more challenging, usually, the quality of the detection degrades causing one of the objects to be missed or creating a single big detection that includes both objects. On top of the detection issues, the tracker needs to decide which detection should be matched to which TrackedObject which can be error-prone if only considering spatial information. The solution is not easy but incorporating the notion of the appearance similarity based on some kind of embedding to your distance_finction can help.
+    - Mismatches when objects overlap. In this case, tracking becomes more challenging, usually, the quality of the detection degrades causing one of the objects to be missed or creating a single big detection that includes both objects. On top of the detection issues, the tracker needs to decide which detection should be matched to which TrackedObject which can be error-prone if only considering spatial information. The solution is not easy but incorporating the notion of the appearance similarity based on some kind of embedding to your distance_function can help.
 - Can't **recover** an object **after occlusions**. Use ReID distance, see [this demo](https://github.com/tryolabs/norfair/tree/master/demos/reid) for an example but for real-world use you will need a good ReID model that can provide good embeddings.

--- a/norfair/__init__.py
+++ b/norfair/__init__.py
@@ -6,7 +6,7 @@ Examples
 >>> from norfair import Detection, Tracker, Video, draw_tracked_objects
 >>> detector = MyDetector()  # Set up a detector
 >>> video = Video(input_path="video.mp4")
->>> tracker = Tracker(distance_function="frobenious", distance_threshold=50)
+>>> tracker = Tracker(distance_function="euclidean", distance_threshold=50)
 >>> for frame in video:
 >>>    detections = detector(frame)
 >>>    norfair_detections = [Detection(points) for points in detections]

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -1,10 +1,254 @@
 """Predefined distances"""
-from typing import TYPE_CHECKING, Callable
+from abc import ABC, abstractmethod
+from logging import warning
+from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Union
 
 import numpy as np
+from scipy.spatial.distance import cdist
 
 if TYPE_CHECKING:
     from .tracker import Detection, TrackedObject
+
+
+class Distance(ABC):
+    """
+    Abstract class representing a distance.
+
+    Subclasses must implement the method `get_distances`
+    """
+
+    @abstractmethod
+    def get_distances(
+        self,
+        objects: Sequence["TrackedObject"],
+        candidates: Optional[Union[List["Detection"], List["TrackedObject"]]],
+    ) -> np.ndarray:
+        """
+        Method that calculates the distances between new candidates and objects.
+
+        Parameters
+        ----------
+        objects: Sequence[TrackedObject]
+            Sequence of [TrackedObject][norfair.tracker.TrackedObject] to be compared with potential [Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]
+            candidates.
+        candidates: Union[List[Detection], List[TrackedObject]], optional
+            List of candidates ([Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]) to be compared to [TrackedObject][norfair.tracker.TrackedObject].
+
+        Returns
+        -------
+        np.ndarray
+            A matrix containing the distances between objects and candidates.
+        """
+        pass
+
+
+class ScalarDistance(Distance):
+    """
+    ScalarDistance class represents a distance that is calculated pointwise.
+
+    Parameters
+    ----------
+    distance_function : Union[
+            Callable[["Detection", "TrackedObject"], float],
+            Callable[["TrackedObject", "TrackedObject"], float],
+        ],
+        Distance function used to determine the pointwise distance between new candidates and objects.
+        This function should take 2 input arguments, the first being a `Union[Detection, TrackedObject]`,
+        and the second [TrackedObject][norfair.tracker.TrackedObject]. It has to return a `float` with the distance it calculates.
+    """
+
+    def __init__(
+        self,
+        distance_function: Union[
+            Callable[["Detection", "TrackedObject"], float],
+            Callable[["TrackedObject", "TrackedObject"], float],
+        ],
+    ):
+        self.distance_function = distance_function
+
+    def get_distances(
+        self,
+        objects: Sequence["TrackedObject"],
+        candidates: Optional[Union[List["Detection"], List["TrackedObject"]]],
+    ) -> np.ndarray:
+        """
+        Method that calculates the distances between new candidates and objects.
+
+        Parameters
+        ----------
+        objects: Sequence[TrackedObject]
+            Sequence of [TrackedObject][norfair.tracker.TrackedObject] to be compared with potential [Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]
+            candidates.
+        candidates: Union[List[Detection], List[TrackedObject]], optional
+            List of candidates ([Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]) to be compared to [TrackedObject][norfair.tracker.TrackedObject].
+
+        Returns
+        -------
+        np.ndarray
+            A matrix containing the distances between objects and candidates.
+        """
+        distance_matrix = np.full(
+            (len(candidates), len(objects)),
+            fill_value=np.inf,
+            dtype=np.float32,
+        )
+        if not objects or not candidates:
+            return distance_matrix
+        for c, candidate in enumerate(candidates):
+            for o, obj in enumerate(objects):
+                if candidate.label != obj.label:
+                    if (candidate.label is None) or (obj.label is None):
+                        print("\nThere are detections with and without label!")
+                    continue
+                distance = self.distance_function(candidate, obj)
+                distance_matrix[c, o] = distance
+        return distance_matrix
+
+
+class VectorizedDistance(Distance):
+    """
+    VectorizedDistance class represents a distance that is calculated pairwise.
+
+    Parameters
+    ----------
+    distance_function : Callable[[np.ndarray, np.ndarray], np.ndarray]
+        Distance function used to determine the pairwise distances between new candidates and objects.
+        This function should take 2 input arguments, the first being a `np.ndarray` and the second
+        `np.ndarray`. It has to return a `np.ndarray` with the distance matrix it calculates.
+    """
+
+    def __init__(
+        self,
+        distance_function: Callable[[np.ndarray, np.ndarray], np.ndarray],
+    ):
+        self.distance_function = distance_function
+
+    def get_distances(
+        self,
+        objects: Sequence["TrackedObject"],
+        candidates: Optional[Union[List["Detection"], List["TrackedObject"]]],
+    ) -> np.ndarray:
+        """
+        Method that calculates the distances between new candidates and objects.
+
+        Parameters
+        ----------
+        objects: Sequence[TrackedObject]
+            Sequence of [TrackedObject][norfair.tracker.TrackedObject] to be compared with potential [Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]
+            candidates.
+        candidates: Union[List[Detection], List[TrackedObject]], optional
+            List of candidates ([Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]) to be compared to [TrackedObject][norfair.tracker.TrackedObject].
+
+        Returns
+        -------
+        np.ndarray
+            A matrix containing the distances between objects and candidates.
+        """
+        distance_matrix = np.full(
+            (len(candidates), len(objects)),
+            fill_value=np.inf,
+            dtype=np.float32,
+        )
+        if not objects or not candidates:
+            return distance_matrix
+
+        object_labels = np.array([o.label for o in objects]).astype(str)
+        candidate_labels = np.array([c.label for c in candidates]).astype(str)
+
+        # iterate over labels that are present both in objects and detections
+        for label in np.intersect1d(
+            np.unique(object_labels), np.unique(candidate_labels)
+        ):
+            # generate masks of the subset of object and detections for this label
+            obj_mask = object_labels == label
+            cand_mask = candidate_labels == label
+
+            stacked_objects = []
+            for o in objects:
+                if str(o.label) == label:
+                    stacked_objects.append(o.estimate.ravel())
+            stacked_objects = np.stack(stacked_objects)
+
+            stacked_candidates = []
+            for c in candidates:
+                if str(c.label) == label:
+                    if "Detection" in str(type(c)):
+                        stacked_candidates.append(c.points.ravel())
+                    else:
+                        stacked_candidates.append(c.estimate.ravel())
+            stacked_candidates = np.stack(stacked_candidates)
+
+            # calculate the pairwise distances between objects and candidates with this label
+            # and assign the result to the correct positions inside distance_matrix
+            distance_matrix[np.ix_(cand_mask, obj_mask)] = self._compute_distance(
+                stacked_candidates, stacked_objects
+            )
+
+        return distance_matrix
+
+    def _compute_distance(
+        self, stacked_candidates: np.ndarray, stacked_objects: np.ndarray
+    ) -> np.ndarray:
+        """
+        Method that computes the pairwise distances between new candidates and objects.
+
+        Parameters
+        ----------
+        stacked_candidates: np.ndarray
+            np.ndarray containing a stack of candidates to be compared with the stacked_objects.
+        stacked_objects: np.ndarray
+            np.ndarray containing a stack of objects to be compared with the stacked_objects.
+
+        Returns
+        -------
+        np.ndarray
+            A matrix containing the distances between objects and candidates.
+        """
+        return self.distance_function(stacked_candidates, stacked_objects)
+
+
+class ScipyDistance(VectorizedDistance):
+    """
+    ScipyDistance class extends VectorizedDistance for the use of Scipy's pairwise distances.
+
+    This class uses `scipy.spatial.distance.cdist` to calculate distances between two `np.ndarray`.
+
+    Parameters
+    ----------
+    metric : str, optional
+        Defines the specific Scipy metric to use to calculate the pairwise distances between
+        new candidates and objects.
+
+    See Also
+    --------
+    [`scipy.spatial.distance.cdist`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html)
+    """
+
+    def __init__(
+        self,
+        metric: str = "euclidean",
+    ):
+        self.metric = metric
+
+    def _compute_distance(
+        self, stacked_candidates: np.ndarray, stacked_objects: np.ndarray
+    ) -> np.ndarray:
+        """
+        Method that computes the pairwise distances between new candidates and objects.
+
+        Parameters
+        ----------
+        stacked_candidates: np.ndarray
+            np.ndarray containing a stack of candidates to be compared with the stacked_objects.
+        stacked_objects: np.ndarray
+            np.ndarray containing a stack of objects to be compared with the stacked_objects.
+
+        Returns
+        -------
+        np.ndarray
+            A matrix containing the distances between objects and candidates.
+        """
+        return cdist(stacked_candidates, stacked_objects, metric=self.metric)
 
 
 def frobenius(detection: "Detection", tracked_object: "TrackedObject") -> float:
@@ -196,27 +440,68 @@ def iou_opt(detection: "Detection", tracked_object: "TrackedObject") -> float:
     return _iou(detection.points, tracked_object.estimate)
 
 
-_DISTANCE_FUNCTIONS = {
+_SCALAR_DISTANCE_FUNCTIONS = {
     "frobenius": frobenius,
     "mean_manhattan": mean_manhattan,
     "mean_euclidean": mean_euclidean,
     "iou": iou,
     "iou_opt": iou_opt,
 }
+_VECTORIZED_DISTANCE_FUNCTIONS = {}
+_SCIPY_DISTANCE_FUNCTIONS = [
+    "braycurtis",
+    "canberra",
+    "chebyshev",
+    "cityblock",
+    "correlation",
+    "cosine",
+    "dice",
+    "euclidean",
+    "hamming",
+    "jaccard",
+    "jensenshannon",
+    "kulczynski1",
+    "mahalanobis",
+    "matching",
+    "minkowski",
+    "rogerstanimoto",
+    "russellrao",
+    "seuclidean",
+    "sokalmichener",
+    "sokalsneath",
+    "sqeuclidean",
+    "yule",
+]
 
 
-def get_distance_by_name(name: str) -> Callable[["Detection", "TrackedObject"], float]:
-    """
+def get_distance_by_name(name: str) -> Distance:
+    f"""
     Select a distance by name.
 
-    Valid names are: `["frobenius", "mean_euclidean", "mean_manhattan", "iou", "iou_opt"]`.
+    Valid names are: `{list(_SCALAR_DISTANCE_FUNCTIONS.keys()) + list(_VECTORIZED_DISTANCE_FUNCTIONS.keys()) + _SCIPY_DISTANCE_FUNCTIONS}`.
     """
-    try:
-        return _DISTANCE_FUNCTIONS[name]
-    except KeyError:
-        raise ValueError(
-            f"Invalid distance '{name}', expecting one of {_DISTANCE_FUNCTIONS.keys()}"
+
+    if name in _SCALAR_DISTANCE_FUNCTIONS:
+        warning(
+            "You are using a scalar distance function. If you want to speed up the"
+            " tracking process please consider using a vectorized distance function"
+            " such as"
+            f" {list(_VECTORIZED_DISTANCE_FUNCTIONS.keys()) + _SCIPY_DISTANCE_FUNCTIONS}."
         )
+        distance = _SCALAR_DISTANCE_FUNCTIONS[name]
+        distance_function = ScalarDistance(distance)
+    elif name in _SCIPY_DISTANCE_FUNCTIONS:
+        distance_function = ScipyDistance(name)
+    elif name in _VECTORIZED_DISTANCE_FUNCTIONS:
+        distance = _VECTORIZED_DISTANCE_FUNCTIONS[name]
+        distance_function = VectorizedDistance(distance)
+    else:
+        raise ValueError(
+            f"Invalid distance '{name}', expecting one of"
+            f" {list(_SCALAR_DISTANCE_FUNCTIONS.keys()) + list(_VECTORIZED_DISTANCE_FUNCTIONS.keys()) + _SCIPY_DISTANCE_FUNCTIONS}"
+        )
+
+    return distance_function
 
 
 def create_keypoints_voting_distance(

--- a/norfair/drawing.py
+++ b/norfair/drawing.py
@@ -790,7 +790,7 @@ class FixedCamera:
     Examples
     --------
     >>> # setup
-    >>> tracker = Tracker("frobenious", 100)
+    >>> tracker = Tracker("euclidean", 100)
     >>> motion_estimator = MotionEstimator()
     >>> video = Video(input_path="video.mp4")
     >>> fixed_camera = FixedCamera()

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -7,8 +7,7 @@ from rich import print
 from norfair.camera_motion import CoordinatesTransformation
 
 from .distances import (
-    _SCIPY_DISTANCE_FUNCTIONS,
-    _VECTORIZED_DISTANCE_FUNCTIONS,
+    AVAILABLE_VECTORIZED_DISTANCES,
     ScalarDistance,
     get_distance_by_name,
 )
@@ -103,8 +102,7 @@ class Tracker:
             warning(
                 "You are using a scalar distance function. If you want to speed up the"
                 " tracking process please consider using a vectorized distance"
-                " function such as"
-                f" {list(_VECTORIZED_DISTANCE_FUNCTIONS.keys()) + _SCIPY_DISTANCE_FUNCTIONS}."
+                f" function such as {AVAILABLE_VECTORIZED_DISTANCES}."
             )
             distance_function = ScalarDistance(distance_function)
         else:

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -1,3 +1,4 @@
+from logging import warning
 from typing import Any, Callable, Hashable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -5,7 +6,12 @@ from rich import print
 
 from norfair.camera_motion import CoordinatesTransformation
 
-from .distances import get_distance_by_name
+from .distances import (
+    _SCIPY_DISTANCE_FUNCTIONS,
+    _VECTORIZED_DISTANCE_FUNCTIONS,
+    ScalarDistance,
+    get_distance_by_name,
+)
 from .filter import FilterFactory, OptimizedKalmanFilterFactory
 from .utils import validate_points
 
@@ -21,6 +27,8 @@ class Tracker:
         This function should take 2 input arguments, the first being a [Detection][norfair.tracker.Detection], and the second a [TrackedObject][norfair.tracker.TrackedObject].
         It has to return a `float` with the distance it calculates.
         Some common distances are implemented in [distances][], as a shortcut the tracker accepts the name of these [predefined distances][norfair.distances.get_distance_by_name].
+        Scipy's predefined distances are also accepted. A `str` with one of the available metrics in
+        [`scipy.spatial.distance.cdist`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html).
     distance_threshold : float
         Defines what is the maximum distance that can constitute a match.
         Detections and tracked objects whose distances are above this threshold won't be matched by the tracker.
@@ -91,6 +99,19 @@ class Tracker:
 
         if isinstance(distance_function, str):
             distance_function = get_distance_by_name(distance_function)
+        elif isinstance(distance_function, Callable):
+            warning(
+                "You are using a scalar distance function. If you want to speed up the"
+                " tracking process please consider using a vectorized distance"
+                " function such as"
+                f" {list(_VECTORIZED_DISTANCE_FUNCTIONS.keys()) + _SCIPY_DISTANCE_FUNCTIONS}."
+            )
+            distance_function = ScalarDistance(distance_function)
+        else:
+            raise ValueError(
+                "Argument `distance_function` should be a string or function but is"
+                f" {type(distance_function)} instead."
+            )
         self.distance_function = distance_function
 
         self.hit_counter_max = hit_counter_max
@@ -115,7 +136,10 @@ class Tracker:
 
         self.distance_threshold = distance_threshold
         self.detection_threshold = detection_threshold
-        self.reid_distance_function = reid_distance_function
+        if reid_distance_function is not None:
+            self.reid_distance_function = ScalarDistance(reid_distance_function)
+        else:
+            self.reid_distance_function = reid_distance_function
         self.reid_distance_threshold = reid_distance_threshold
         self._obj_factory = _TrackedObjectFactory()
 
@@ -261,33 +285,6 @@ class Tracker:
             if not o.is_initializing and o.hit_counter_is_positive
         ]
 
-    def _get_distances(
-        self,
-        distance_function,
-        distance_threshold,
-        objects: Sequence["TrackedObject"],
-        candidates: Optional[Union[List["Detection"], List["TrackedObject"]]],
-    ):
-        distance_matrix = np.ones((len(candidates), len(objects)), dtype=np.float32)
-        distance_matrix *= distance_threshold + 1
-        for c, candidate in enumerate(candidates):
-            for o, obj in enumerate(objects):
-                if candidate.label != obj.label:
-                    distance_matrix[c, o] = distance_threshold + 1
-                    if (candidate.label is None) or (obj.label is None):
-                        print("\nThere are detections with and without label!")
-                    continue
-                distance = distance_function(candidate, obj)
-                # Cap detections and objects with no chance of getting matched so we
-                # dont force the hungarian algorithm to minimize them and therefore
-                # introduce the possibility of sub optimal results.
-                # Note: This is probably not needed with the new distance minimizing algorithm
-                if distance > distance_threshold:
-                    distance_matrix[c, o] = distance_threshold + 1
-                else:
-                    distance_matrix[c, o] = distance
-        return distance_matrix
-
     def _update_objects_in_place(
         self,
         distance_function,
@@ -297,9 +294,7 @@ class Tracker:
         period: int,
     ):
         if candidates is not None and len(candidates) > 0:
-            distance_matrix = self._get_distances(
-                distance_function, distance_threshold, objects, candidates
-            )
+            distance_matrix = distance_function.get_distances(objects, candidates)
             if np.isnan(distance_matrix).any():
                 print(
                     "\nReceived nan values from distance function, please check your distance function for errors!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 python = "^3.6.1"
 filterpy = "^1.4.5"
 rich = ">=9.10.0, <13.0.0"
+scipy = ">=1.5.4"
 opencv-python = { version = ">= 3.2.0, < 5.0.0", optional = true }
 motmetrics = { version = "1.2.5", optional = true }
 importlib-metadata = { version = "4.8.3", python = "<3.8" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from norfair.utils import validate_points
 @pytest.fixture
 def mock_det():
     class FakeDetection:
-        def __init__(self, points, scores=None) -> None:
+        def __init__(self, points, scores=None, label=None) -> None:
             if not isinstance(points, np.ndarray):
                 points = np.array(points)
             self.points = points
@@ -17,6 +17,7 @@ def mock_det():
                 if scores.ndim == 0 and points.shape[0] > 1:
                     scores = np.full(points.shape[0], scores)
             self.scores = scores
+            self.label = label
 
     return FakeDetection
 
@@ -24,12 +25,13 @@ def mock_det():
 @pytest.fixture
 def mock_obj(mock_det):
     class FakeTrackedObject:
-        def __init__(self, points, scores=None):
+        def __init__(self, points, scores=None, label=None):
             if not isinstance(points, np.ndarray):
                 points = np.array(points)
 
             self.estimate = points
             self.last_detection = mock_det(points, scores=scores)
+            self.label = label
 
     return FakeTrackedObject
 

--- a/tests/mot_metrics.py
+++ b/tests/mot_metrics.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 from norfair import FilterPyKalmanFilterFactory, Tracker, metrics
-from norfair.distances import iou
 
 DATASET_PATH = "train"
 MOTA_ERROR_THRESHOLD = 0.0
@@ -48,7 +47,7 @@ def mot_metrics():
         )
 
         tracker = Tracker(
-            distance_function=iou,
+            distance_function="iou",
             distance_threshold=DISTANCE_THRESHOLD,
             detection_threshold=DETECTION_THRESHOLD,
             pointwise_hit_counter_max=POINTWISE_HIT_COUNTER_MAX,

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -2,8 +2,12 @@ import numpy as np
 import pytest
 
 from norfair.distances import (
+    ScalarDistance,
+    ScipyDistance,
+    VectorizedDistance,
     create_keypoints_voting_distance,
     create_normalized_mean_euclidean_distance,
+    frobenius,
     get_distance_by_name,
 )
 
@@ -14,37 +18,37 @@ def test_frobenius(mock_obj, mock_det):
     # perfect match
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[1, 2], [3, 4]])
-    np.testing.assert_almost_equal(fro(det, obj), 0)
+    np.testing.assert_almost_equal(fro.distance_function(det, obj), 0)
 
     # foat type
     det = mock_det([[1.1, 2.2], [3.3, 4.4]])
     obj = mock_obj([[1.1, 2.2], [3.3, 4.4]])
-    np.testing.assert_almost_equal(fro(det, obj), 0)
+    np.testing.assert_almost_equal(fro.distance_function(det, obj), 0)
 
     # distance of 1 in 1 dimension of 1 point
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[2, 2], [3, 4]])
-    np.testing.assert_almost_equal(fro(det, obj), np.sqrt(1))
+    np.testing.assert_almost_equal(fro.distance_function(det, obj), np.sqrt(1))
 
     # distance of 2 in 1 dimension of 1 point
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[3, 2], [3, 4]])
-    np.testing.assert_almost_equal(fro(det, obj), 2)
+    np.testing.assert_almost_equal(fro.distance_function(det, obj), 2)
 
     # distance of 1 in all dimensions of all points
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[2, 3], [4, 5]])
-    np.testing.assert_almost_equal(fro(det, obj), np.sqrt(4))
+    np.testing.assert_almost_equal(fro.distance_function(det, obj), np.sqrt(4))
 
     # negative difference
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[-1, 2], [3, 4]])
-    np.testing.assert_almost_equal(fro(det, obj), 2)
+    np.testing.assert_almost_equal(fro.distance_function(det, obj), 2)
 
     # negative equals
     det = mock_det([[-1, 2], [3, 4]])
     obj = mock_obj([[-1, 2], [3, 4]])
-    np.testing.assert_almost_equal(fro(det, obj), 0)
+    np.testing.assert_almost_equal(fro.distance_function(det, obj), 0)
 
 
 def test_mean_manhattan(mock_det, mock_obj):
@@ -53,37 +57,37 @@ def test_mean_manhattan(mock_det, mock_obj):
     # perfect match
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[1, 2], [3, 4]])
-    np.testing.assert_almost_equal(man(det, obj), 0)
+    np.testing.assert_almost_equal(man.distance_function(det, obj), 0)
 
     # foat type
     det = mock_det([[1.1, 2.2], [3.3, 4.4]])
     obj = mock_obj([[1.1, 2.2], [3.3, 4.4]])
-    np.testing.assert_almost_equal(man(det, obj), 0)
+    np.testing.assert_almost_equal(man.distance_function(det, obj), 0)
 
     # distance of 1 in 1 dimension of 1 point
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[2, 2], [3, 4]])
-    np.testing.assert_almost_equal(man(det, obj), 1 / 2)
+    np.testing.assert_almost_equal(man.distance_function(det, obj), 1 / 2)
 
     # distance of 2 in 1 dimension of 1 point
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[3, 2], [3, 4]])
-    np.testing.assert_almost_equal(man(det, obj), 1)
+    np.testing.assert_almost_equal(man.distance_function(det, obj), 1)
 
     # distance of 1 in all dimensions of all points
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[2, 3], [4, 5]])
-    np.testing.assert_almost_equal(man(det, obj), 2)
+    np.testing.assert_almost_equal(man.distance_function(det, obj), 2)
 
     # negative difference
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[-1, 2], [3, 4]])
-    np.testing.assert_almost_equal(man(det, obj), 1)
+    np.testing.assert_almost_equal(man.distance_function(det, obj), 1)
 
     # negative equals
     det = mock_det([[-1, 2], [3, 4]])
     obj = mock_obj([[-1, 2], [3, 4]])
-    np.testing.assert_almost_equal(man(det, obj), 0)
+    np.testing.assert_almost_equal(man.distance_function(det, obj), 0)
 
 
 def test_mean_euclidean(mock_det, mock_obj):
@@ -92,47 +96,47 @@ def test_mean_euclidean(mock_det, mock_obj):
     # perfect match
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[1, 2], [3, 4]])
-    np.testing.assert_almost_equal(euc(det, obj), 0)
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), 0)
 
     # foat type
     det = mock_det([[1.1, 2.2], [3.3, 4.4]])
     obj = mock_obj([[1.1, 2.2], [3.3, 4.4]])
-    np.testing.assert_almost_equal(euc(det, obj), 0)
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), 0)
 
     # distance of 1 in 1 dimension of 1 point
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[2, 2], [3, 4]])
-    np.testing.assert_almost_equal(euc(det, obj), 1 / 2)
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), 1 / 2)
 
     # distance of 2 in 1 dimension of 1 point
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[3, 2], [3, 4]])
-    np.testing.assert_almost_equal(euc(det, obj), 1)
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), 1)
 
     # distance of 2 in 1 dimension of all points
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[3, 2], [5, 4]])
-    np.testing.assert_almost_equal(euc(det, obj), 2)
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), 2)
 
     # distance of 2 in all dimensions of all points
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[3, 4], [5, 6]])
-    np.testing.assert_almost_equal(euc(det, obj), np.sqrt(8))
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), np.sqrt(8))
 
     # distance of 1 in all dimensions of all points
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[2, 3], [4, 5]])
-    np.testing.assert_almost_equal(euc(det, obj), np.sqrt(2))
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), np.sqrt(2))
 
     # negative difference
     det = mock_det([[1, 2], [3, 4]])
     obj = mock_obj([[-1, 2], [3, 4]])
-    np.testing.assert_almost_equal(euc(det, obj), 1)
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), 1)
 
     # negative equals
     det = mock_det([[-1, 2], [3, 4]])
     obj = mock_obj([[-1, 2], [3, 4]])
-    np.testing.assert_almost_equal(euc(det, obj), 0)
+    np.testing.assert_almost_equal(euc.distance_function(det, obj), 0)
 
 
 def test_iou(mock_det, mock_obj):
@@ -142,60 +146,60 @@ def test_iou(mock_det, mock_obj):
     # perfect match
     det = mock_det([[0, 0], [1, 1]])
     obj = mock_obj([[0, 0], [1, 1]])
-    np.testing.assert_almost_equal(iou(det, obj), 0)
-    np.testing.assert_almost_equal(iou_opt(det, obj), 0)
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
+    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 0)
 
     # float type
     det = mock_det([[0.0, 0.0], [1.1, 1.1]])
     obj = mock_obj([[0.0, 0.0], [1.1, 1.1]])
-    np.testing.assert_almost_equal(iou(det, obj), 0)
-    np.testing.assert_almost_equal(iou_opt(det, obj), 0)
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
+    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 0)
 
     # det contained in obj
     det = mock_det([[0, 0], [1, 1]])
     obj = mock_obj([[0, 0], [2, 2]])
-    np.testing.assert_almost_equal(iou(det, obj), 1 - 1 / 4)
-    np.testing.assert_almost_equal(iou_opt(det, obj), 1 - 1 / 4)
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / 4)
+    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / 4)
 
     # no overlap
     det = mock_det([[0, 0], [1, 1]])
     obj = mock_obj([[1, 1], [2, 2]])
-    np.testing.assert_almost_equal(iou(det, obj), 1)
-    np.testing.assert_almost_equal(iou_opt(det, obj), 1)
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 1)
+    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1)
 
     # obj fully contained on det
     det = mock_det([[0, 0], [4, 4]])
     obj = mock_obj([[1, 1], [2, 2]])
-    np.testing.assert_almost_equal(iou(det, obj), 1 - 1 / 16)
-    np.testing.assert_almost_equal(iou_opt(det, obj), 1 - 1 / 16)
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / 16)
+    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / 16)
 
     # partial overlap
     det = mock_det([[0, 0], [2, 2]])
     obj = mock_obj([[1, 1], [3, 3]])
-    np.testing.assert_almost_equal(iou(det, obj), 1 - 1 / (8 - 1))
-    np.testing.assert_almost_equal(iou_opt(det, obj), 1 - 1 / (8 - 1))
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / (8 - 1))
+    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / (8 - 1))
 
     # invalid bbox
     det = mock_det([[0, 0]])
     obj = mock_obj([[0, 0]])
     with pytest.raises(AssertionError):
-        iou(det, obj)
+        iou.distance_function(det, obj)
 
     # invalid bbox
     det = mock_det([[0, 0], [1, 1], [2, 2]])
     obj = mock_obj([[0, 0], [2, 2]])
     with pytest.raises(AssertionError):
-        iou(det, obj)
+        iou.distance_function(det, obj)
 
     # invalid box should be corrected
     det = mock_det([[4, 4], [0, 0]])
     obj = mock_obj([[0, 0], [4, 4]])
-    np.testing.assert_almost_equal(iou(det, obj), 0)
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
 
     # invalid box should be corrected
     det = mock_det([[0, 0], [4, 4]])
     obj = mock_obj([[4, 4], [0, 0]])
-    np.testing.assert_almost_equal(iou(det, obj), 0)
+    np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
 
 
 def test_keypoint_vote(mock_obj, mock_det):
@@ -286,3 +290,53 @@ def test_normalized_euclidean(mock_obj, mock_det):
     det = mock_det([[-1, 2], [3, 4]])
     obj = mock_obj([[-1, 2], [3, 4]])
     np.testing.assert_almost_equal(norm_e(det, obj), 0)
+
+
+def test_scalar_distance(mock_obj, mock_det):
+    fro = ScalarDistance(frobenius)
+
+    det = mock_det([[1, 2], [3, 4]])
+    obj = mock_obj([[1, 2], [3, 4]])
+
+    dist_matrix = fro.get_distances([obj], [det])
+
+    assert type(dist_matrix) == np.ndarray
+    assert dist_matrix.shape == (1, 1)
+    assert dist_matrix[0, 0] == 0
+
+
+def test_vectorized_distance(mock_obj, mock_det):
+    def distance_function(cands, objs):
+        distance_matrix = np.full(
+            (len(cands), len(objs)),
+            fill_value=np.inf,
+            dtype=np.float32,
+        )
+        for c, cand in enumerate(cands):
+            for o, obj in enumerate(objs):
+                distance_matrix[c, o] = np.linalg.norm(cand - obj)
+        return distance_matrix
+
+    fro = VectorizedDistance(distance_function)
+
+    det = mock_det([[1, 2], [3, 4]])
+    obj = mock_obj([[1, 2], [3, 4]])
+
+    dist_matrix = fro.get_distances([obj], [det])
+
+    assert type(dist_matrix) == np.ndarray
+    assert dist_matrix.shape == (1, 1)
+    assert dist_matrix[0, 0] == 0
+
+
+def test_scipy_distance(mock_obj, mock_det):
+    euc = ScipyDistance("euclidean")
+
+    det = mock_det([[1, 2], [3, 4]])
+    obj = mock_obj([[1, 2], [4, 4]])
+
+    dist_matrix = euc.get_distances([obj], [det])
+
+    assert type(dist_matrix) == np.ndarray
+    assert dist_matrix.shape == (1, 1)
+    assert dist_matrix[0, 0] == 1.0

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -15,17 +15,17 @@ def test_params():
     # test some invalid initializations
     #
     with pytest.raises(ValueError):
-        Tracker("frobenius", distance_threshold=10, initialization_delay=-1)
+        Tracker("euclidean", distance_threshold=10, initialization_delay=-1)
     with pytest.raises(ValueError):
         Tracker(
-            "frobenius",
+            "euclidean",
             distance_threshold=10,
             initialization_delay=1,
             hit_counter_max=0,
         )
     with pytest.raises(ValueError):
         Tracker(
-            "frobenius",
+            "euclidean",
             distance_threshold=10,
             initialization_delay=1,
             hit_counter_max=1,
@@ -49,7 +49,7 @@ def test_simple(filter_factory):
             # tests a simple static detection
             #
             tracker = Tracker(
-                "frobenius",
+                "euclidean",
                 initialization_delay=delay,
                 distance_threshold=100,
                 hit_counter_max=counter_max,
@@ -108,7 +108,7 @@ def test_moving(filter_factory):
     # Test a simple case of a moving object
     #
     tracker = Tracker(
-        "frobenius",
+        "euclidean",
         initialization_delay=3,
         distance_threshold=100,
         filter_factory=filter_factory,
@@ -133,7 +133,7 @@ def test_distance_t(filter_factory):
     # Test a moving object with a small distance threshold
     #
     tracker = Tracker(
-        "frobenius",
+        "euclidean",
         initialization_delay=1,
         distance_threshold=1,
         filter_factory=filter_factory,
@@ -161,7 +161,7 @@ def test_1d_points(filter_factory, mock_coordinate_transformation):
     # Test a detection with rank 1
     #
     tracker = Tracker(
-        "frobenius",
+        "euclidean",
         initialization_delay=0,
         distance_threshold=1,
         filter_factory=filter_factory,
@@ -180,7 +180,7 @@ def test_camera_motion(mock_coordinate_transformation):
     # Simple test for camera motion
     #
     for one_d in [True, False]:
-        tracker = Tracker("frobenius", 1, initialization_delay=0)
+        tracker = Tracker("euclidean", 1, initialization_delay=0)
         if one_d:
             absolute_points = np.array([1, 1])
         else:
@@ -225,7 +225,7 @@ def test_count(delay):
         # tests a simple static detection
         #
         tracker = Tracker(
-            "frobenius",
+            "euclidean",
             initialization_delay=delay,
             distance_threshold=1,
             hit_counter_max=counter_max,
@@ -276,13 +276,13 @@ def test_count(delay):
 
 def test_multiple_trackers():
     tracker1 = Tracker(
-        "frobenius",
+        "euclidean",
         initialization_delay=0,
         distance_threshold=1,
         hit_counter_max=2,
     )
     tracker2 = Tracker(
-        "frobenius",
+        "euclidean",
         initialization_delay=0,
         distance_threshold=1,
         hit_counter_max=2,


### PR DESCRIPTION
In this PR we add support for vectorized `distance_functions` to speed up Norfair. The new distances can be one of `ScalarDistance`, `VectorizedDistance`, and `ScipyDistance`. We moved the distance functions and the distances calculations (previously `Tracker._get_distances`) to the newly mentioned classes. With this new interface, we can define a variety of distances; from simple scalar distances such as the ones that we have been using until now, to custom vectorized distances that take a pair of `np.ndarray` as input, and even default vectorized distances from `Scipy`. 

We were careful not to break the API. The users can still define custom distances and now they can also leverage predefined vectorized distances that speed up the tracking. 

Changes include:
- Defined new distance classes in `distances.py`.
- Removed the `Tracker._get_distances` and moved it to the distance classes.
- Adapted `Tracker.__init__` to create instances of the new distance classes.
- Adapted demos to use vectorized distances when possible.
- Adapted tests and include new ones for the new distances interface.
- Updated deprecated documentation in README.


Pending tasks:
[ x ] Change demos to use vectorized distances when possible
[ x ] Check ReID still works
[ x ] Add tests
[ x ] Review and update any deprecated documentation 
[ x ] Write PR description