### PR TITLE
Add optimized IoU function in Cython.

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,28 @@
+from setuptools import Extension
+
+import Cython.Build
+import numpy
+
+
+extension = Extension(
+    "optimized_iou",
+    sources=["norfair/optimized_iou.pyx"],
+    include_dirs=[numpy.get_include()],
+)
+
+
+def build(setup_kwargs):
+    """
+    Build the optimized IoU distance module implemented in Cython.
+
+    Parameters
+    ----------
+    setup_kwargs : Any
+        This parameter is required to be able to build with Poetry.
+    """
+    setup_kwargs.update(
+        {
+            # declare the extension so that setuptools will compile it
+            "ext_modules": Cython.Build.cythonize(extension, language_level=3),
+        }
+    )

--- a/norfair/optimized_iou.pyx
+++ b/norfair/optimized_iou.pyx
@@ -1,0 +1,48 @@
+import numpy as np
+cimport numpy as np
+
+DTYPE = float
+ctypedef np.float_t DTYPE_t
+
+
+def iou_opt(
+        np.ndarray[DTYPE_t, ndim=2] candidates,
+        np.ndarray[DTYPE_t, ndim=2] objects
+) -> np.ndarray:
+    """
+    Calculate IoU between bounding boxes. 
+    Based on https://github.com/rbgirshick/fast-rcnn/blob/master/lib/utils/bbox.pyx
+
+    Parameters
+    ----------
+    candidates : numpy.ndarray
+        (N, 4) numpy.ndarray of float containing candidates bounding boxes.
+    objects : numpy.ndarray
+        (K, 4) numpy.ndarray of float containing objects bounding boxes.
+
+    Returns
+    -------
+    numpy.ndarray
+        (N, K) numpy.ndarray of IoU between candidates and objects.
+    """
+    cdef unsigned int N = candidates.shape[0]
+    cdef unsigned int K = objects.shape[0]
+    cdef np.ndarray[DTYPE_t, ndim=2] ious = np.zeros((N, K), dtype=DTYPE)
+    cdef DTYPE_t cand_area, inter_height, inter_width, obj_area, union_area
+    cdef unsigned int k, n
+
+    for k in range(K):
+        obj_area = (objects[k, 2] - objects[k, 0]) * (objects[k, 3] - objects[k, 1])
+        for n in range(N):
+            inter_width = (min(candidates[n, 2], objects[k, 2]) -
+                           max(candidates[n, 0], objects[k, 0]))
+            if inter_width > 0:
+                inter_height = (min(candidates[n, 3], objects[k, 3]) -
+                                max(candidates[n, 1], objects[k, 1]))
+                if inter_height > 0:
+                    cand_area = (candidates[n, 2] - candidates[n, 0]) * (
+                                candidates[n, 3] - candidates[n, 1])
+                    union_area = float(cand_area + obj_area -
+                                       inter_width * inter_height)
+                    ious[n, k] = inter_width * inter_height / union_area
+    return 1 - ious

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,7 +41,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "black"
@@ -104,6 +104,14 @@ description = "Composable style cycles"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "Cython"
+version = "0.29.32"
+description = "The Cython compiler for writing C extensions for the Python language."
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "dataclasses"
@@ -196,9 +204,9 @@ python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "kiwisolver"
@@ -365,7 +373,7 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
-name = "pillow"
+name = "Pillow"
 version = "8.4.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
@@ -408,7 +416,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "pygments"
+name = "Pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
@@ -602,7 +610,7 @@ python-versions = "*"
 
 [[package]]
 name = "virtualenv"
-version = "20.16.7"
+version = "20.17.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -654,7 +662,7 @@ video = ["opencv-python"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "4d793eaaf8548f9bfc320824c953a8129a3e05d9963266bc3b2c3dc70681d3ec"
+content-hash = "d6246096006b601143aa2ef221353c892413670d080a2c3916eeb7601e1b2d28"
 
 [metadata.files]
 appdirs = [
@@ -690,6 +698,48 @@ commonmark = [
 cycler = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
+]
+Cython = [
+    {file = "Cython-0.29.32-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:39afb4679b8c6bf7ccb15b24025568f4f9b4d7f9bf3cbd981021f542acecd75b"},
+    {file = "Cython-0.29.32-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:dbee03b8d42dca924e6aa057b836a064c769ddfd2a4c2919e65da2c8a362d528"},
+    {file = "Cython-0.29.32-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ba622326f2862f9c1f99ca8d47ade49871241920a352c917e16861e25b0e5c3"},
+    {file = "Cython-0.29.32-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e6ffa08aa1c111a1ebcbd1cf4afaaec120bc0bbdec3f2545f8bb7d3e8e77a1cd"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:97335b2cd4acebf30d14e2855d882de83ad838491a09be2011745579ac975833"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:06be83490c906b6429b4389e13487a26254ccaad2eef6f3d4ee21d8d3a4aaa2b"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:eefd2b9a5f38ded8d859fe96cc28d7d06e098dc3f677e7adbafda4dcdd4a461c"},
+    {file = "Cython-0.29.32-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5514f3b4122cb22317122a48e175a7194e18e1803ca555c4c959d7dfe68eaf98"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:656dc5ff1d269de4d11ee8542f2ffd15ab466c447c1f10e5b8aba6f561967276"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:cdf10af3e2e3279dc09fdc5f95deaa624850a53913f30350ceee824dc14fc1a6"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:3875c2b2ea752816a4d7ae59d45bb546e7c4c79093c83e3ba7f4d9051dd02928"},
+    {file = "Cython-0.29.32-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:79e3bab19cf1b021b613567c22eb18b76c0c547b9bc3903881a07bfd9e7e64cf"},
+    {file = "Cython-0.29.32-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0595aee62809ba353cebc5c7978e0e443760c3e882e2c7672c73ffe46383673"},
+    {file = "Cython-0.29.32-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0ea8267fc373a2c5064ad77d8ff7bf0ea8b88f7407098ff51829381f8ec1d5d9"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:c8e8025f496b5acb6ba95da2fb3e9dacffc97d9a92711aacfdd42f9c5927e094"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:afbce249133a830f121b917f8c9404a44f2950e0e4f5d1e68f043da4c2e9f457"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:513e9707407608ac0d306c8b09d55a28be23ea4152cbd356ceaec0f32ef08d65"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e83228e0994497900af954adcac27f64c9a57cd70a9ec768ab0cb2c01fd15cf1"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ea1dcc07bfb37367b639415333cfbfe4a93c3be340edf1db10964bc27d42ed64"},
+    {file = "Cython-0.29.32-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8669cadeb26d9a58a5e6b8ce34d2c8986cc3b5c0bfa77eda6ceb471596cb2ec3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:ed087eeb88a8cf96c60fb76c5c3b5fb87188adee5e179f89ec9ad9a43c0c54b3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:3f85eb2343d20d91a4ea9cf14e5748092b376a64b7e07fc224e85b2753e9070b"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:63b79d9e1f7c4d1f498ab1322156a0d7dc1b6004bf981a8abda3f66800e140cd"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e1958e0227a4a6a2c06fd6e35b7469de50adf174102454db397cec6e1403cce3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:856d2fec682b3f31583719cb6925c6cdbb9aa30f03122bcc45c65c8b6f515754"},
+    {file = "Cython-0.29.32-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:479690d2892ca56d34812fe6ab8f58e4b2e0129140f3d94518f15993c40553da"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:67fdd2f652f8d4840042e2d2d91e15636ba2bcdcd92e7e5ffbc68e6ef633a754"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:4a4b03ab483271f69221c3210f7cde0dcc456749ecf8243b95bc7a701e5677e0"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:40eff7aa26e91cf108fd740ffd4daf49f39b2fdffadabc7292b4b7dc5df879f0"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0bbc27abdf6aebfa1bce34cd92bd403070356f28b0ecb3198ff8a182791d58b9"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cddc47ec746a08603037731f5d10aebf770ced08666100bd2cdcaf06a85d4d1b"},
+    {file = "Cython-0.29.32-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:eca3065a1279456e81c615211d025ea11bfe4e19f0c5650b859868ca04b3fcbd"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d968ffc403d92addf20b68924d95428d523436adfd25cf505d427ed7ba3bee8b"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f3fd44cc362eee8ae569025f070d56208908916794b6ab21e139cea56470a2b3"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:b6da3063c5c476f5311fd76854abae6c315f1513ef7d7904deed2e774623bbb9"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:061e25151c38f2361bc790d3bcf7f9d9828a0b6a4d5afa56fbed3bd33fb2373a"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f9944013588a3543fca795fffb0a070a31a243aa4f2d212f118aa95e69485831"},
+    {file = "Cython-0.29.32-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:07d173d3289415bb496e72cb0ddd609961be08fe2968c39094d5712ffb78672b"},
+    {file = "Cython-0.29.32-py2.py3-none-any.whl", hash = "sha256:eeb475eb6f0ccf6c039035eb4f0f928eb53ead88777e0a760eccb140ad90930b"},
+    {file = "Cython-0.29.32.tar.gz", hash = "sha256:8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
@@ -952,7 +1002,7 @@ pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
-pillow = [
+Pillow = [
     {file = "Pillow-8.4.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d"},
     {file = "Pillow-8.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6"},
     {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb9fc393f3c61f9054e1ed26e6fe912c7321af2f41ff49d3f83d05bacf22cc78"},
@@ -1007,7 +1057,7 @@ py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
-pygments = [
+Pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
     {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
 ]
@@ -1204,8 +1254,8 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.16.7-py3-none-any.whl", hash = "sha256:efd66b00386fdb7dbe4822d172303f40cd05e50e01740b19ea42425cbe653e29"},
-    {file = "virtualenv-20.16.7.tar.gz", hash = "sha256:8691e3ff9387f743e00f6bb20f70121f5e4f596cae754531f2b3b3a1b1ac696e"},
+    {file = "virtualenv-20.17.0-py3-none-any.whl", hash = "sha256:40a7e06a98728fd5769e1af6fd1a706005b4bb7e16176a272ed4292473180389"},
+    {file = "virtualenv-20.17.0.tar.gz", hash = "sha256:7d6a8d55b2f73b617f684ee40fd85740f062e1f2e379412cb1879c7136f05902"},
 ]
 wrapt = [
     {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ license = "BSD-3-Clause"
 authors = ["Tryolabs <hello@tryolabs.com>"]
 repository = "https://github.com/tryolabs/norfair"
 readme = "README.md"
+build = "build.py"
 keywords = [
     "tracking",
     "object-detection",
@@ -56,12 +57,13 @@ tox = "^3.26.0"
 [tool.poetry.group.dev.dependencies]
 black = "^20.8b1"
 isort = "^5.10.1"
+cython = "^0.29.32"
 
 [build-system]
 # Need >= 1.1.0a6 to work on Python 3.6 or we get
 # "The Poetry configuration is invalid" because of dependency
 # groups. Otherwise can use >= 1.0.0.
-requires = ["poetry-core>=1.1.0a6"]
+requires = ["poetry-core>=1.1.0a6", "cython", "setuptools", "numpy"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.isort]

--- a/tests/mot_metrics.py
+++ b/tests/mot_metrics.py
@@ -47,7 +47,7 @@ def mot_metrics():
         )
 
         tracker = Tracker(
-            distance_function="iou",
+            distance_function="iou_opt",
             distance_threshold=DISTANCE_THRESHOLD,
             detection_threshold=DETECTION_THRESHOLD,
             pointwise_hit_counter_max=POINTWISE_HIT_COUNTER_MAX,

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -10,6 +10,7 @@ from norfair.distances import (
     frobenius,
     get_distance_by_name,
 )
+from optimized_iou import DTYPE
 
 
 def test_frobenius(mock_obj, mock_det):
@@ -147,37 +148,61 @@ def test_iou(mock_det, mock_obj):
     det = mock_det([[0, 0], [1, 1]])
     obj = mock_obj([[0, 0], [1, 1]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 0)
+    det.points = det.points.reshape(1, 4).astype(DTYPE)
+    obj.estimate = obj.estimate.reshape(1, 4).astype(DTYPE)
+    np.testing.assert_almost_equal(
+        iou_opt.distance_function(det.points, obj.estimate), 0
+    )
 
     # float type
     det = mock_det([[0.0, 0.0], [1.1, 1.1]])
     obj = mock_obj([[0.0, 0.0], [1.1, 1.1]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 0)
+    det.points = det.points.reshape(1, 4).astype(DTYPE)
+    obj.estimate = obj.estimate.reshape(1, 4).astype(DTYPE)
+    np.testing.assert_almost_equal(
+        iou_opt.distance_function(det.points, obj.estimate), 0
+    )
 
     # det contained in obj
     det = mock_det([[0, 0], [1, 1]])
     obj = mock_obj([[0, 0], [2, 2]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / 4)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / 4)
+    det.points = det.points.reshape(1, 4).astype(DTYPE)
+    obj.estimate = obj.estimate.reshape(1, 4).astype(DTYPE)
+    np.testing.assert_almost_equal(
+        iou_opt.distance_function(det.points, obj.estimate), 1 - 1 / 4
+    )
 
     # no overlap
     det = mock_det([[0, 0], [1, 1]])
     obj = mock_obj([[1, 1], [2, 2]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1)
+    det.points = det.points.reshape(1, 4).astype(DTYPE)
+    obj.estimate = obj.estimate.reshape(1, 4).astype(DTYPE)
+    np.testing.assert_almost_equal(
+        iou_opt.distance_function(det.points, obj.estimate), 1
+    )
 
     # obj fully contained on det
     det = mock_det([[0, 0], [4, 4]])
     obj = mock_obj([[1, 1], [2, 2]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / 16)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / 16)
+    det.points = det.points.reshape(1, 4).astype(DTYPE)
+    obj.estimate = obj.estimate.reshape(1, 4).astype(DTYPE)
+    np.testing.assert_almost_equal(
+        iou_opt.distance_function(det.points, obj.estimate), 1 - 1 / 16
+    )
 
     # partial overlap
     det = mock_det([[0, 0], [2, 2]])
     obj = mock_obj([[1, 1], [3, 3]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / (8 - 1))
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / (8 - 1))
+    det.points = det.points.reshape(1, 4).astype(DTYPE)
+    obj.estimate = obj.estimate.reshape(1, 4).astype(DTYPE)
+    np.testing.assert_almost_equal(
+        iou_opt.distance_function(det.points, obj.estimate), 1 - 1 / (8 - 1)
+    )
 
     # invalid bbox
     det = mock_det([[0, 0]])


### PR DESCRIPTION
This PR adds a new implementation for the IoU distance calculation. In particular, to speed up the process of calculating distances, we implemented the new module in Cython. This resulted in x10 speed up in some scenarios. 

We now use this optimized IoU compiled module in Norfair. For this purpose, we must ensure the module gets correctly compiled when installing Norfair. For now, we won't be distributing platform-specific wheels since we are not releasing a new version of Norfair. The module will get compiled on the user's end when installing Norfair with pip. In a future PR, we will address the necessary changes to distribute the package with the corresponding precompiled versions for each platform. 

Changes include:
- Implementation of optimized IoU in Cython
- Add build.py for building the new module
  - this gets included in the setup.py when installing Norfair
- Modification of tests accordingly 
- Integration of new IoU distance function with distances API


Pending:
- [X] Rebase when https://github.com/tryolabs/norfair/pull/211 gets merged.
- [x] Integrate Cython IoU with vectorized distances new API
- [x] Check ReID is still working 
- [x] Check linting issue
- [x] Write tests 
- [x] Write PR's description
- [x] Check issue when installing with poetry