### PR TITLE
Set Ubuntu version to 20.04 in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   # versions of Python.
   #
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
       matrix:
@@ -51,7 +51,7 @@ jobs:
           tox -e py
 
   mot-metrics:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -73,7 +73,7 @@ jobs:
           tox -e mot-py39
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -101,7 +101,7 @@ jobs:
 
   install:
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
       matrix:
@@ -130,7 +130,7 @@ jobs:
   # Executed only if GitHub release is "published".
   #
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [unit-tests, mot-metrics]
     if: github.event_name == 'release'
     env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: release-drafter/release-drafter@v5
         env:


### PR DESCRIPTION
[Recently](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/), GitHub Actions `ubuntu-latest` tag started pointing to Ubuntu 22.04, leading to failures when setting up Python 3.6. We now set our GA to use `ubuntu-20.04` so that we can run checks for Python 3.6. 

> NOTE: When we decide not to support Python 3.6 anymore, we could update the Ubuntu version to 22.04.