### PR TITLE
Add optimized IoU function

### DIFF
--- a/demos/motmetrics4norfair/src/motmetrics4norfair.py
+++ b/demos/motmetrics4norfair/src/motmetrics4norfair.py
@@ -102,7 +102,7 @@ for input_path in sequences_paths:
     )
 
     tracker = Tracker(
-        distance_function="iou_opt",
+        distance_function="iou",
         distance_threshold=DISTANCE_THRESHOLD,
         detection_threshold=DETECTION_THRESHOLD,
         pointwise_hit_counter_max=POINTWISE_HIT_COUNTER_MAX,

--- a/demos/yolov5/src/demo.py
+++ b/demos/yolov5/src/demo.py
@@ -126,7 +126,7 @@ model = YOLO(args.model_name, device=args.device)
 for input_path in args.files:
     video = Video(input_path=input_path)
 
-    distance_function = "iou_opt" if args.track_points == "bbox" else "euclidean"
+    distance_function = "iou" if args.track_points == "bbox" else "euclidean"
     distance_threshold = (
         DISTANCE_THRESHOLD_BBOX
         if args.track_points == "bbox"

--- a/demos/yolov7/src/demo.py
+++ b/demos/yolov7/src/demo.py
@@ -136,7 +136,7 @@ model = YOLO(args.detector_path, device=args.device)
 for input_path in args.files:
     video = Video(input_path=input_path)
 
-    distance_function = "iou_opt" if args.track_points == "bbox" else "euclidean"
+    distance_function = "iou" if args.track_points == "bbox" else "euclidean"
 
     distance_threshold = (
         DISTANCE_THRESHOLD_BBOX

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -357,7 +357,9 @@ def _validate_bboxes(bboxes: np.ndarray):
     Validate that bounding boxes are well formed.
     """
     assert (
-        type(bboxes) == np.ndarray and len(bboxes.shape) == 2 and bboxes.shape[1] == 4
+        isinstance(bboxes, np.ndarray)
+        and len(bboxes.shape) == 2
+        and bboxes.shape[1] == 4
     ), f"Bounding boxes must be defined as np.array with (N, 4) shape, {bboxes} given"
 
     if not (all(bboxes[:, 0] < bboxes[:, 2]) and all(bboxes[:, 1] < bboxes[:, 3])):

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -345,110 +345,75 @@ def mean_manhattan(detection: "Detection", tracked_object: "TrackedObject") -> f
     ).mean()
 
 
-def _validate_bboxes(bbox: np.ndarray):
-    """Validates that the numpy array a is a valid bounding box"""
-    assert bbox.shape == (
-        2,
-        2,
-    ), f"incorrect bbox, expecting shape (2, 2) but received {bbox.shape}"
-
-    assert bbox[0, 0] < bbox[1, 0] and bbox[0, 1] < bbox[1, 1], f"incorrect bbox {bbox}"
-
-
-def _iou(box_a, box_b) -> float:
+def _boxes_area(boxes: np.ndarray) -> np.ndarray:
     """
-    Underlying iou distance. See `Norfair.distances.iou`.
+    Calculate the area of bounding boxes.
     """
-
-    # Detection points will be box A
-    # Tracked objects point will be box B.
-    box_a = np.concatenate(box_a)
-    box_b = np.concatenate(box_b)
-    x_a = max(box_a[0], box_b[0])
-    y_a = max(box_a[1], box_b[1])
-    x_b = min(box_a[2], box_b[2])
-    y_b = min(box_a[3], box_b[3])
-
-    # Compute the area of intersection rectangle
-    inter_area = max(0, x_b - x_a) * max(0, y_b - y_a)
-
-    # Compute the area of both the prediction and tracker
-    # rectangles
-    box_a_area = (box_a[2] - box_a[0]) * (box_a[3] - box_a[1])
-    box_b_area = (box_b[2] - box_b[0]) * (box_b[3] - box_b[1])
-
-    # Compute the intersection over union by taking the intersection
-    # area and dividing it by the sum of prediction + tracker
-    # areas - the interesection area
-    iou = inter_area / float(box_a_area + box_b_area - inter_area)
-    # Since 0 <= IoU <= 1, we define 1-IoU as a distance.
-    # Distance values will be in [0, 1]
-    return 1 - iou
+    return (boxes[2] - boxes[0]) * (boxes[3] - boxes[1])
 
 
-def iou(detection: "Detection", tracked_object: "TrackedObject") -> float:
+def _validate_bboxes(bboxes: np.ndarray):
     """
-    Intersection over union distance between the bounding boxes.
+    Validate that bounding boxes are well formed.
+    """
+    assert (
+        type(bboxes) == np.ndarray and len(bboxes.shape) == 2 and bboxes.shape[1] == 4
+    ), f"Bounding boxes must be defined as np.array with (N, 4) shape, {bboxes} given"
 
-    Assumes that `detection.points` (and by consecuence `tracked_object.estimate`)
-    define a bounding box in the form `[[x0, y0], [x1, y1]]`.
+    if not (all(bboxes[:, 0] < bboxes[:, 2]) and all(bboxes[:, 1] < bboxes[:, 3])):
+        warning(
+            f"Incorrect bounding boxes. Check that x_min < x_max and y_min < y_max."
+        )
+
+
+def iou(candidates: np.ndarray, objects: np.ndarray) -> np.ndarray:
+    """
+    Calculate IoU between two sets of bounding boxes. Both sets of boxes are expected
+    to be in `[x_min, y_min, x_max, y_max]` format.
 
     Normal IoU is 1 when the boxes are the same and 0 when they don't overlap,
     to transform that into a distance that makes sense we return `1 - iou`.
 
-    Performs checks that the bounding boxes are valid to give better error messages.
-    For a faster implementation without checks use [`iou_opt`][norfair.distances.iou_opt].
-
     Parameters
     ----------
-    detection : Detection
-        A detection.
-    tracked_object : TrackedObject
-        A tracked object.
+    candidates : numpy.ndarray
+        (N, 4) numpy.ndarray containing candidates bounding boxes.
+    objects : numpy.ndarray
+        (K, 4) numpy.ndarray containing objects bounding boxes.
 
     Returns
     -------
-    float
-        The distance.
+    numpy.ndarray
+        (N, K) numpy.ndarray of `1 - iou` between candidates and objects.
     """
-    boxa = detection.points.copy()
-    boxa.sort(axis=0)
-    _validate_bboxes(boxa)
-    boxb = tracked_object.estimate.copy()
-    boxb.sort(axis=0)
-    _validate_bboxes(boxb)
-    return _iou(boxa, boxb)
+    _validate_bboxes(candidates)
+
+    area_candidates = _boxes_area(candidates.T)
+    area_objects = _boxes_area(objects.T)
+
+    top_left = np.maximum(candidates[:, None, :2], objects[:, :2])
+    bottom_right = np.minimum(candidates[:, None, 2:], objects[:, 2:])
+
+    area_intersection = np.prod(
+        np.clip(bottom_right - top_left, a_min=0, a_max=None), 2
+    )
+    return 1 - area_intersection / (
+        area_candidates[:, None] + area_objects - area_intersection
+    )
 
 
-def iou_opt(detection: "Detection", tracked_object: "TrackedObject") -> float:
-    """
-    Optimized version of [`iou`][norfair.distances.iou].
-
-    Performs faster but errors might be cryptic if the bounding boxes are not valid.
-
-    Parameters
-    ----------
-    detection : Detection
-        A detection.
-    tracked_object : TrackedObject
-        A tracked object.
-
-    Returns
-    -------
-    float
-        The distance.
-    """
-    return _iou(detection.points, tracked_object.estimate)
+iou_opt = iou  # deprecated
 
 
 _SCALAR_DISTANCE_FUNCTIONS = {
     "frobenius": frobenius,
     "mean_manhattan": mean_manhattan,
     "mean_euclidean": mean_euclidean,
-    "iou": iou,
-    "iou_opt": iou_opt,
 }
-_VECTORIZED_DISTANCE_FUNCTIONS = {}
+_VECTORIZED_DISTANCE_FUNCTIONS = {
+    "iou": iou,
+    "iou_opt": iou,  # deprecated
+}
 _SCIPY_DISTANCE_FUNCTIONS = [
     "braycurtis",
     "canberra",
@@ -504,6 +469,8 @@ def get_distance_by_name(name: str) -> Distance:
     elif name in _SCIPY_DISTANCE_FUNCTIONS:
         distance_function = ScipyDistance(name)
     elif name in _VECTORIZED_DISTANCE_FUNCTIONS:
+        if name == "iou_opt":
+            warning("iou_opt is deprecated, use iou instead")
         distance = _VECTORIZED_DISTANCE_FUNCTIONS[name]
         distance_function = VectorizedDistance(distance)
     else:

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -139,67 +139,50 @@ def test_mean_euclidean(mock_det, mock_obj):
     np.testing.assert_almost_equal(euc.distance_function(det, obj), 0)
 
 
-def test_iou(mock_det, mock_obj):
+def test_iou():
     iou = get_distance_by_name("iou")
-    iou_opt = get_distance_by_name("iou_opt")
 
     # perfect match
-    det = mock_det([[0, 0], [1, 1]])
-    obj = mock_obj([[0, 0], [1, 1]])
+    det = np.array([[0, 0, 1, 1]])
+    obj = np.array([[0, 0, 1, 1]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 0)
 
     # float type
-    det = mock_det([[0.0, 0.0], [1.1, 1.1]])
-    obj = mock_obj([[0.0, 0.0], [1.1, 1.1]])
+    det = np.array([[0.0, 0.0, 1.1, 1.1]])
+    obj = np.array([[0.0, 0.0, 1.1, 1.1]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 0)
 
     # det contained in obj
-    det = mock_det([[0, 0], [1, 1]])
-    obj = mock_obj([[0, 0], [2, 2]])
+    det = np.array([[0, 0, 1, 1]])
+    obj = np.array([[0, 0, 2, 2]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / 4)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / 4)
 
     # no overlap
-    det = mock_det([[0, 0], [1, 1]])
-    obj = mock_obj([[1, 1], [2, 2]])
+    det = np.array([[0, 0, 1, 1]])
+    obj = np.array([[1, 1, 2, 2]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1)
 
     # obj fully contained on det
-    det = mock_det([[0, 0], [4, 4]])
-    obj = mock_obj([[1, 1], [2, 2]])
+    det = np.array([[0, 0, 4, 4]])
+    obj = np.array([[1, 1, 2, 2]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / 16)
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / 16)
 
     # partial overlap
-    det = mock_det([[0, 0], [2, 2]])
-    obj = mock_obj([[1, 1], [3, 3]])
+    det = np.array([[0, 0, 2, 2]])
+    obj = np.array([[1, 1, 3, 3]])
     np.testing.assert_almost_equal(iou.distance_function(det, obj), 1 - 1 / (8 - 1))
-    np.testing.assert_almost_equal(iou_opt.distance_function(det, obj), 1 - 1 / (8 - 1))
 
     # invalid bbox
-    det = mock_det([[0, 0]])
-    obj = mock_obj([[0, 0]])
+    det = np.array([[0, 0]])
+    obj = np.array([[0, 0]])
     with pytest.raises(AssertionError):
         iou.distance_function(det, obj)
 
     # invalid bbox
-    det = mock_det([[0, 0], [1, 1], [2, 2]])
-    obj = mock_obj([[0, 0], [2, 2]])
+    det = np.array([[0, 0, 1, 1, 2, 2]])
+    obj = np.array([[0, 0, 2, 2]])
     with pytest.raises(AssertionError):
         iou.distance_function(det, obj)
-
-    # invalid box should be corrected
-    det = mock_det([[4, 4], [0, 0]])
-    obj = mock_obj([[0, 0], [4, 4]])
-    np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
-
-    # invalid box should be corrected
-    det = mock_det([[0, 0], [4, 4]])
-    obj = mock_obj([[4, 4], [0, 0]])
-    np.testing.assert_almost_equal(iou.distance_function(det, obj), 0)
 
 
 def test_keypoint_vote(mock_obj, mock_det):


### PR DESCRIPTION
This PR adds a new implementation for the IoU distance calculation by leveraging `numpy` for vectorized calculations.

Changes include:
- Implementation of a vectorized IoU
- Modification of tests accordingly
- Adapt demos to remove deprecated `iou_opt`

> NOTE: We also implemented an optimized IoU function in Cython at https://github.com/tryolabs/norfair/pull/213, but after profiling both implementations, we saw that the performance was almost the same. Thus we decided to use the one introduced in this PR due to its simplicity.

Pending:
- [x] Test on some demos