### PR TITLE
Enable users to draw custom objects 

### DIFF
--- a/norfair/drawing/__init__.py
+++ b/norfair/drawing/__init__.py
@@ -3,5 +3,6 @@ from .absolute_grid import draw_absolute_grid
 from .color import Color, ColorType, Palette
 from .draw_boxes import draw_boxes, draw_tracked_boxes
 from .draw_points import draw_points, draw_tracked_objects
+from .drawer import Drawable
 from .fixed_camera import FixedCamera
 from .path import AbsolutePaths, Paths

--- a/norfair/drawing/draw_boxes.py
+++ b/norfair/drawing/draw_boxes.py
@@ -132,7 +132,10 @@ def draw_boxes(
         text_color = parse_color(text_color)
 
     for obj in drawables:
-        d = Drawable(obj)
+        if not isinstance(obj, Drawable):
+            d = Drawable(obj)
+        else:
+            d = obj
 
         if color == "by_id":
             obj_color = Palette.choose_color(d.id)

--- a/norfair/drawing/draw_points.py
+++ b/norfair/drawing/draw_points.py
@@ -126,7 +126,10 @@ def draw_points(
         radius = int(round(max(max(frame.shape) * 0.002, 1)))
 
     for o in drawables:
-        d = Drawable(o)
+        if not isinstance(o, Drawable):
+            d = Drawable(o)
+        else:
+            d = o
 
         if hide_dead_points and not d.live_points.any():
             continue

--- a/norfair/drawing/drawer.py
+++ b/norfair/drawing/drawer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -304,8 +304,20 @@ class Drawable:
 
     Parameters
     ----------
-    obj : Union[Detection, TrackedObject]
+    obj : Union[Detection, TrackedObject], optional
         A [Detection][norfair.tracker.Detection] or a [TrackedObject][norfair.tracker.TrackedObject]
+        that will be used to initialized the drawable.
+        If this parameter is passed, all other arguments are ignored
+    points : np.ndarray, optional
+        Points included in the drawable, shape is `(N_points, N_dimensions)`. Ignored if `obj` is passed
+    id : Any, optional
+        Id of this object. Ignored if `obj` is passed
+    label : Any, optional
+        Label specifying the class of the object. Ignored if `obj` is passed
+    scores : np.ndarray, optional
+        Confidence scores of each point, shape is `(N_points,)`. Ignored if `obj` is passed
+    live_points : np.ndarray, optional
+        Bolean array indicating which points are alive, shape is `(N_points,)`. Ignored if `obj` is passed
 
     Raises
     ------
@@ -313,7 +325,15 @@ class Drawable:
         If obj is not an instance of the supported classes.
     """
 
-    def __init__(self, obj: Union[Detection, TrackedObject]) -> None:
+    def __init__(
+        self,
+        obj: Union[Detection, TrackedObject] = None,
+        points: np.ndarray = None,
+        id: Any = None,
+        label: Any = None,
+        scores: np.ndarray = None,
+        live_points: np.ndarray = None,
+    ) -> None:
         if isinstance(obj, Detection):
             self.points = obj.points
             self.id = None
@@ -331,6 +351,12 @@ class Drawable:
             # it could be the scores of the last detection or some kind of moving average
             self.scores = None
             self.live_points = obj.live_points
+        elif obj is None:
+            self.points = points
+            self.id = id
+            self.label = label
+            self.scores = scores
+            self.live_points = live_points
         else:
             raise ValueError(
                 f"Extecting a Detection or a TrackedObject but received {type(obj)}"


### PR DESCRIPTION
This PR addresses a specific use-case when the users want to draw a `TrackedObject` but they only have the data of the object and not the instance. This can happen when the `TrackedObject` is serialized and restored.

It's hard (if not impossible) for users to instantiate a TrackedObject directly when they want to draw it. With this change, the Drawable class can be instantiated directly and then drawn like so:

``` python
draw_boxes(
    frame,
    drawables=[
        Drawable(
            points=np.array([[20, 20], [50, 90]]),
            label="person",
            id=123,
            scores=np.array([0.88]),
        )
    ],
)
```