### PR TITLE
Fix deprecated `Color.random` call in 3d-track demo.

### DIFF
--- a/demos/3d_track/src/utils.py
+++ b/demos/3d_track/src/utils.py
@@ -1,7 +1,7 @@
 import cv2
 import numpy as np
 
-from norfair import Color
+from norfair import Palette
 
 CONNECTED_INDEXES = [1, 2, 4, 3, 1, 5, 7, 3, 7, 8, 6, 5, 6, 2, 4, 8]
 
@@ -146,7 +146,7 @@ def draw_3d_tracked_boxes(
         if draw_only_alive and not obj.live_points.any():
             continue
         if border_colors is None:
-            color = Color.random(obj.id)
+            color = Palette.choose_color(obj.id)
         else:
             color = border_colors[n % len(border_colors)]
 


### PR DESCRIPTION
We were pointed out in https://github.com/tryolabs/norfair/issues/243 that the demo for 3d tracking was using the deprecated `Color.random()` to set a random color for the boxes. This PR fixes that by changing it for the new `Palette.choose_color()`. I also checked for other appearances of the deprecated `Color.random()` but didn't find any.