### PR TITLE
Fix colab demo

### DIFF
--- a/demos/colab/requirements.txt
+++ b/demos/colab/requirements.txt
@@ -1,6 +1,5 @@
 torch==1.12.1
 torchvision==0.13.1
-numpy==1.21.6
 rich==12.5.1
 opencv-python==4.6.0.66
 tqdm==4.64.1


### PR DESCRIPTION
The colab demo `requirements.txt` included `numpy==1.21.6`, but we now have `numpy` as a direct dependency on `Norfair`, so we don't need to set that version anymore. This was making the installation of requirements fail.

> NOTE: To test this PR, you should change the URL where you download the `requirements.txt` files from Norfair so that it uses the new branch's version (e.g. change `https://raw.githubusercontent.com/tryolabs/norfair/master/demos/colab/requirements.txt` for `https://raw.githubusercontent.com/tryolabs/norfair/fix-colab-demo/demos/colab/requirements.txt`)