### PR TITLE
Fix path drawer

### DIFF
--- a/norfair/drawing/path.py
+++ b/norfair/drawing/path.py
@@ -111,7 +111,7 @@ class Paths:
             points_to_draw = self.get_points_to_draw(obj.estimate)
 
             for point in points_to_draw:
-                frame = Drawer.circle(
+                self.mask = Drawer.circle(
                     self.mask,
                     position=tuple(point.astype(int)),
                     radius=self.radius,


### PR DESCRIPTION
After [this](https://github.com/tryolabs/norfair/issues/251) issue, we identify that the `Paths` class was returning a black image with the paths. This was caused by the `draw` method, something unexpected.

We were assigning the mask with the paths to the `frame` variable and this is the cause of the fusion of two undesired images in [this](https://github.com/tryolabs/norfair/blob/8c843db26004260d970d7c4747926644c65a0d2f/norfair/drawing/path.py#L122) line.