### PR TITLE
Set default value `draw_ids` to True in the `draw_boxes` function

### DIFF
--- a/norfair/drawing/draw_boxes.py
+++ b/norfair/drawing/draw_boxes.py
@@ -19,7 +19,7 @@ def draw_boxes(
     color_by_label: bool = None,  # Deprecated
     draw_labels: bool = False,
     text_size: Optional[float] = None,
-    draw_ids: bool = False,
+    draw_ids: bool = True,
     text_color: Optional[ColorLike] = None,
     text_thickness: Optional[int] = None,
     draw_box: bool = True,


### PR DESCRIPTION
TBD:
The `draw_points` function has a default value of True for the `draw_ids` argument. However, the `draw_boxes` function has a default value of False for the same argument. It may be useful to draw the IDs assigned by the tracker for debugging purposes. Therefore, it is expected that the `draw_boxes` function should draw the IDs in the same way as the `draw_points` function.