### PR TITLE
Updated docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,8 @@
-mkdocs-material==8.4.1
-mkdocstrings[python]==0.19.0
-mkdocs-autorefs==0.4.1
-mkdocs-gen-files==0.4.0
-mike==1.1.2
+mkdocs-material==9.5.6
+mkdocstrings[python]==0.24.0
+mkdocs-autorefs==0.5.0
+mkdocs-gen-files==0.5.0
+mike==2.0.0
+mkdocs==1.5.3
+mkdocs-material-extensions==1.3.1
+mkdocstrings-python==1.8.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
 plugins:
   - search
   - mkdocstrings:
-      custom_templates: templates
+      # custom_templates: templates
       default_handler: python
       handlers:
           python:


### PR DESCRIPTION
The docs deploy GA was [broken](https://github.com/tryolabs/norfair/actions/runs/7712768871/job/21021054093).

Probably this was caused by not having all the dependencies frozen in `docs/requirements.txt` which allowed some plugins to update causing compatibility issues.

In this PR I upgraded the versions and added some missing packages. I also had to comment the `templates` config which was not being used.