### PR TITLE
Set draw_labels to false by default

### DIFF
--- a/norfair/drawing/draw_points.py
+++ b/norfair/drawing/draw_points.py
@@ -17,7 +17,7 @@ def draw_points(
     thickness: Optional[int] = None,
     color: ColorLike = "by_id",
     color_by_label: bool = None,  # deprecated
-    draw_labels: bool = True,
+    draw_labels: bool = False,
     text_size: Optional[int] = None,
     draw_ids: bool = True,
     draw_points: bool = True,  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
The default value for `draw_labels` was not the same in `draw_boxes` and `draw_points`. For consistency, I think it would be better to have the same default value