### PR TITLE
Simplify frame skipping logic

### DIFF
--- a/demos/openpose/src/demo.py
+++ b/demos/openpose/src/demo.py
@@ -118,11 +118,11 @@ if __name__ == "__main__":
                     ]
                 )
                 tracked_objects = tracker.update(
-                    detections=detections, period=args.skip_frame
+                    detections=detections,
                 )
                 norfair.draw_points(frame, detections)
             else:
-                tracked_objects = tracker.update(period=args.skip_frame)
+                tracked_objects = tracker.update()
 
             norfair.draw_tracked_objects(frame, tracked_objects)
             video.write(frame)

--- a/demos/profiling/src/demo.py
+++ b/demos/profiling/src/demo.py
@@ -52,7 +52,7 @@ def process_video(
             detector_time = time.time()
 
             tracked_objects = tracker.update(
-                detections=detections, period=frame_skip_period
+                detections=detections,
             )
             tracker_time = time.time()
 

--- a/demos/reid/src/demo.py
+++ b/demos/reid/src/demo.py
@@ -77,7 +77,7 @@ def main(
                 else:
                     detection.embedding = None
 
-            tracked_objects = tracker.update(detections=detections, period=skip_period)
+            tracked_objects = tracker.update(detections=detections)
         else:
             tracked_objects = tracker.update()
         draw_points(cv2_frame, detections)

--- a/demos/sahi/src/demo.py
+++ b/demos/sahi/src/demo.py
@@ -70,7 +70,7 @@ def main(
                 result = get_prediction(frame, detection_model)
 
             detections = get_detections(result.object_prediction_list)
-            tracked_objects = tracker.update(detections=detections, period=skip_period)
+            tracked_objects = tracker.update(detections=detections)
         else:
             tracked_objects = tracker.update()
 


### PR DESCRIPTION
In norfair, whenever you skip frames, the `hit_counter` of each TrackedObjects gets decreased by one. Therefore, when you skip more frames than the value of the `hit_counter`, then the object gets destroyed, even though you didn’t even use the detector! That is undesirable. Also, the `period` variable doesn't seem intuitive on what is doing.

The way it works in this PR is:
- The Tracker.update method doesn't have the `period` argument, but instead it has a `hit_counter_jump` variable (which defaults to None) telling you by how much will the hit_counter get increased or decreased if the frame is not skipped.
- When you call the Tracker.update method, if you pass the argument detections=None, then norfair assumes you skipped that frame, and sets `hit_counter_jump=0`. If detections is a list, then Norfair assumes you didn’t skip that frame, and (by default, if `hit_counter_jump is None`) sets `hit_counter_jump` to one plus the amount of frames that were previously skipped (so if no frames were skipped, then `hit_counter_jump=1`)
- Doing this, whenever you skip a frame, the hit_counters are not touched. Objects that were alive will still be alive at least until the next time you use the detector.
- Whenever you don’t skip a frame, then hit_counters get increased or decreased by hit_counter_jump (depending if they matched or not with a detection). 
- When a `TrackedObject` instance is created, it's initial `hit_counter` is set to 1.


TO DO:
- A lot more testing
- Update markdowns with documentation